### PR TITLE
Refactor/migrate components to zustand

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -4,8 +4,6 @@
     "packages/client/src/store/useAppStore.ts"
   ],
   "ignoreDependencies": [
-    "zustand",
-    "nanoid",
     "axios",
     "cors",
     "dotenv",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,7 +3,7 @@ import { WorkspaceHeader } from "@/components/workspace-header"
 import { RequestControls } from "@/components/request-controls"
 import { RequestEditor } from "@/components/request-editor"
 import { ResponseViewer } from "@/components/response-viewer"
-import { useAppStore } from "@proxymity/client/src/store/useAppStore"
+import { useAppStore } from "@/store/useAppStore"
 
 function App() {
   const [roomId] = useState<string>("example-room-id");

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,25 +3,19 @@ import { WorkspaceHeader } from "@/components/workspace-header"
 import { RequestControls } from "@/components/request-controls"
 import { RequestEditor } from "@/components/request-editor"
 import { ResponseViewer } from "@/components/response-viewer"
-import type { IRequestData, IResponseData } from "@proxymity/shared/src/types"
+import { useAppStore } from "@proxymity/client/src/store/useAppStore"
 
 function App() {
   const [roomId] = useState<string>("example-room-id");
   const [activeUsers] = useState<number>(3);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const [request, setRequest] = useState<IRequestData>({
-    method: "GET",
-    url: "https://api.example.com/users",
-    headers: [],
-    queryParams: [],
-    body: "",
-  })
-
-  const [response, setResponse] = useState<IResponseData | null>(null)
+  const setResponse = useAppStore((state) => state.setResponse);
+  const setLoading = useAppStore((state) => state.setLoading);
 
   const handleSendRequest = async () => {
-    setIsLoading(true)
+    const currentRequest = useAppStore.getState().request;
+    console.log("Sending request:", currentRequest);
+    setLoading(true)
     // Simulate API call
     setTimeout(() => {
       setResponse({
@@ -41,7 +35,7 @@ function App() {
         size: 2048,
         timestamp: Date.now(),
       })
-      setIsLoading(false)
+      setLoading(false)
     }, 1000)
   }
 
@@ -52,19 +46,16 @@ function App() {
 
       <div className="flex flex-1 flex-col overflow-hidden">
         <RequestControls
-          request={request}
-          onRequestChange={setRequest}
           onSend={handleSendRequest}
-          isLoading={isLoading}
         />
 
         <div className="flex flex-1 overflow-hidden">
           <div className="w-1/2 border-r border-border overflow-hidden">
-            <RequestEditor request={request} onRequestChange={setRequest} />
+            <RequestEditor/>
           </div>
 
           <div className="w-1/2 overflow-hidden">
-            <ResponseViewer response={response} isLoading={isLoading} />
+            <ResponseViewer/>
           </div>
         </div>
       </div>

--- a/packages/client/src/components/key-value-table.tsx
+++ b/packages/client/src/components/key-value-table.tsx
@@ -6,31 +6,14 @@ import type { IKeyValue } from "@proxymity/shared/src/types"
 
 interface KeyValueTableProps {
   items: IKeyValue[]
-  onChange: (items: IKeyValue[]) => void
+  onAdd: () => void
+  onUpdate: (id: string, field: keyof IKeyValue, value: string | boolean) => void;
+  onDelete: (id: string) => void;
   placeholder?: string
 }
 
-export function KeyValueTable({ items, onChange, placeholder = "Key" }: KeyValueTableProps) {
-  const addRow = () => {
-    onChange([
-      ...items,
-      {
-        id: crypto.randomUUID(),
-        key: "",
-        value: "",
-        isEnabled: true,
-      },
-    ])
-  }
-
-  const updateRow = (id: string, field: keyof IKeyValue, value: string | boolean) => {
-    onChange(items.map((item) => (item.id === id ? { ...item, [field]: value } : item)))
-  }
-
-  const deleteRow = (id: string) => {
-    onChange(items.filter((item) => item.id !== id))
-  }
-
+export function KeyValueTable({ items, onAdd, onDelete, onUpdate, placeholder = "Key" }: KeyValueTableProps) {
+  
   return (
     <div className="space-y-2">
       <div className="grid grid-cols-[auto_1fr_1fr_auto] gap-2 text-xs font-medium text-muted-foreground px-2">
@@ -44,13 +27,13 @@ export function KeyValueTable({ items, onChange, placeholder = "Key" }: KeyValue
         <div key={item.id} className="grid grid-cols-[auto_1fr_1fr_auto] gap-2 items-center">
           <Checkbox
             checked={item.isEnabled}
-            onCheckedChange={(checked) => updateRow(item.id, "isEnabled", checked === true)}
+            onCheckedChange={(checked) => onUpdate(item.id, "isEnabled", checked === true)}
           />
           <Input
             type="text"
             placeholder={placeholder}
             value={item.key}
-            onChange={(e) => updateRow(item.id, "key", e.target.value)}
+            onChange={(e) => onUpdate(item.id, "key", e.target.value)}
             className="font-mono text-sm"
             disabled={!item.isEnabled}
           />
@@ -58,17 +41,17 @@ export function KeyValueTable({ items, onChange, placeholder = "Key" }: KeyValue
             type="text"
             placeholder="Value"
             value={item.value}
-            onChange={(e) => updateRow(item.id, "value", e.target.value)}
+            onChange={(e) => onUpdate(item.id, "value", e.target.value)}
             className="font-mono text-sm"
             disabled={!item.isEnabled}
           />
-          <Button variant="ghost" size="icon" onClick={() => deleteRow(item.id)} className="h-8 w-8">
+          <Button variant="ghost" size="icon" onClick={() => onDelete(item.id)} className="h-8 w-8">
             <Trash2 className="h-4 w-4 text-muted-foreground hover:text-destructive" />
           </Button>
         </div>
       ))}
 
-      <Button variant="outline" size="sm" onClick={addRow} className="w-full gap-2 mt-4 bg-transparent">
+      <Button variant="outline" size="sm" onClick={onAdd} className="w-full gap-2 mt-4 bg-transparent">
         <Plus className="h-4 w-4" />
         Add {placeholder}
       </Button>

--- a/packages/client/src/components/request-controls.tsx
+++ b/packages/client/src/components/request-controls.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import type { HttpMethod } from "@proxymity/shared/src/types"
-import { useAppStore } from "@proxymity/client/src/store/useAppStore"
+import { useAppStore } from "@/store/useAppStore"
 
 interface RequestControlsProps {
   onSend: () => void
@@ -59,9 +59,9 @@ export function RequestControls({ onSend }: RequestControlsProps) {
 
       <Button onClick={onSend} disabled={isLoading} className="gap-2 min-w-28" size="default">
         {isLoading ? (
-          <Loader2 className="h-4 w-4 animate-spin" /> // Spinner girando
+          <Loader2 className="h-4 w-4 animate-spin" /> // Loading spinner
         ) : (
-          <Play className="h-4 w-4" /> // Play normal
+          <Play className="h-4 w-4" /> // Play icon
         )}
         {isLoading ? "Sending..." : "Send"}
       </Button>

--- a/packages/client/src/components/request-controls.tsx
+++ b/packages/client/src/components/request-controls.tsx
@@ -12,11 +12,11 @@ interface RequestControlsProps {
 }
 
 const METHOD_COLORS: Record<HttpMethod, string> = {
-  GET: "text-blue-500 bg-blue-500/10",
-  POST: "text-emerald-500 bg-emerald-500/10",
-  PUT: "text-amber-500 bg-amber-500/10",
-  DELETE: "text-red-500 bg-red-500/10",
-  PATCH: "text-purple-500 bg-purple-500/10",
+  GET: "text-blue-500",
+  POST: "text-emerald-500",
+  PUT: "text-amber-500",
+  DELETE: "text-red-500",
+  PATCH: "text-purple-500",
 }
 
 export function RequestControls({ request, onRequestChange, onSend, isLoading }: RequestControlsProps) {
@@ -30,21 +30,17 @@ export function RequestControls({ request, onRequestChange, onSend, isLoading }:
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="GET" className="font-semibold text-blue-500">
-            GET
-          </SelectItem>
-          <SelectItem value="POST" className="font-semibold text-emerald-500">
-            POST
-          </SelectItem>
-          <SelectItem value="PUT" className="font-semibold text-amber-500">
-            PUT
-          </SelectItem>
-          <SelectItem value="DELETE" className="font-semibold text-red-500">
-            DELETE
-          </SelectItem>
-          <SelectItem value="PATCH" className="font-semibold text-purple-500">
-            PATCH
-          </SelectItem>
+          {
+            Object.keys(METHOD_COLORS).map((method) => (
+              <SelectItem
+                key={method}
+                value={method}
+                className={`font-semibold ${METHOD_COLORS[method as HttpMethod]}`}
+              >
+                {method}
+              </SelectItem>
+            ))
+          }
         </SelectContent>
       </Select>
 

--- a/packages/client/src/components/request-controls.tsx
+++ b/packages/client/src/components/request-controls.tsx
@@ -59,7 +59,7 @@ export function RequestControls({ onSend }: RequestControlsProps) {
 
       <Button onClick={onSend} disabled={isLoading} className="gap-2 min-w-28" size="default">
         {isLoading ? (
-          <Loader2 className="h-4 w-4 animate-spin" /> // Spinner girando
+          <Loader2 className="h-4 w-4 animate-spin" /> // Loading spinner
         ) : (
           <Play className="h-4 w-4" /> // Play normal
         )}

--- a/packages/client/src/components/request-controls.tsx
+++ b/packages/client/src/components/request-controls.tsx
@@ -1,14 +1,12 @@
-import { Play } from "lucide-react"
+import { Play, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import type { IRequestData, HttpMethod } from "@proxymity/shared/src/types"
+import type { HttpMethod } from "@proxymity/shared/src/types"
+import { useAppStore } from "@proxymity/client/src/store/useAppStore"
 
 interface RequestControlsProps {
-  request: IRequestData
-  onRequestChange: (request: IRequestData) => void
   onSend: () => void
-  isLoading: boolean
 }
 
 const METHOD_COLORS: Record<HttpMethod, string> = {
@@ -19,14 +17,21 @@ const METHOD_COLORS: Record<HttpMethod, string> = {
   PATCH: "text-purple-500",
 }
 
-export function RequestControls({ request, onRequestChange, onSend, isLoading }: RequestControlsProps) {
+
+export function RequestControls({ onSend }: RequestControlsProps) {
+  const url = useAppStore((state) => state.request.url);
+  const method = useAppStore((state) => state.request.method);
+  const isLoading = useAppStore((state) => state.isLoading);
+  const setUrl = useAppStore((state) => state.setUrl);
+  const setMethod = useAppStore((state) => state.setMethod);
+
   return (
     <div className="flex items-center gap-3 border-b border-border bg-card/50 px-6 py-4">
       <Select
-        value={request.method}
-        onValueChange={(value: HttpMethod) => onRequestChange({ ...request, method: value })}
+        value={method}
+        onValueChange={(value: HttpMethod) => setMethod(value)}
       >
-        <SelectTrigger className={`w-32 font-semibold ${METHOD_COLORS[request.method]}`}>
+        <SelectTrigger className={`w-32 font-semibold ${METHOD_COLORS[method]}`}>
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -47,13 +52,17 @@ export function RequestControls({ request, onRequestChange, onSend, isLoading }:
       <Input
         type="url"
         placeholder="https://api.example.com/endpoint"
-        value={request.url}
-        onChange={(e) => onRequestChange({ ...request, url: e.target.value })}
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
         className="flex-1 font-mono text-sm"
       />
 
-      <Button onClick={onSend} disabled={isLoading} className="gap-2" size="default">
-        <Play className="h-4 w-4" />
+      <Button onClick={onSend} disabled={isLoading} className="gap-2 min-w-28" size="default">
+        {isLoading ? (
+          <Loader2 className="h-4 w-4 animate-spin" /> // Spinner girando
+        ) : (
+          <Play className="h-4 w-4" /> // Play normal
+        )}
         {isLoading ? "Sending..." : "Send"}
       </Button>
     </div>

--- a/packages/client/src/components/request-editor.tsx
+++ b/packages/client/src/components/request-editor.tsx
@@ -4,7 +4,7 @@ import { useAppStore } from "@/store/useAppStore"
 import Editor, { type BeforeMount } from "@monaco-editor/react"
 
 export function RequestEditor() {
-    const handleEditorWillMount: BeforeMount = (monaco) => {
+  const handleEditorWillMount: BeforeMount = (monaco) => {
     monaco.editor.defineTheme('proxymity-dark', {
       base: 'vs-dark',
       inherit: true,
@@ -15,19 +15,20 @@ export function RequestEditor() {
     });
   }
 
-    const request = useAppStore((state) => state.request);
-    const body = request.body;
-    const setBody = useAppStore((state) => state.setBody);
+  const body = useAppStore((state) => state.request.body);
+  const headers = useAppStore((state) => state.request.headers);
+  const queryParams = useAppStore((state) => state.request.queryParams);
+  
+  const setBody = useAppStore((state) => state.setBody);
+  const addHeader = useAppStore((state) => state.addHeader);
+  const removeHeader = useAppStore((state) => state.removeHeader);
+  const updateHeader = useAppStore((state) => state.updateHeader);
 
-    const addHeader = useAppStore((state) => state.addHeader);
-    const removeHeader = useAppStore((state) => state.removeHeader);
-    const updateHeader = useAppStore((state) => state.updateHeader);
+  const addQueryParam = useAppStore((state) => state.addQueryParam);
+  const removeQueryParam = useAppStore((state) => state.removeQueryParam);
+  const updateQueryParam = useAppStore((state) => state.updateQueryParam);
 
-    const addQueryParam = useAppStore((state) => state.addQueryParam);
-    const removeQueryParam = useAppStore((state) => state.removeQueryParam);
-    const updateQueryParam = useAppStore((state) => state.updateQueryParam);
-
-    return (
+  return (
     <div className="flex h-full flex-col">
       <Tabs defaultValue="params" className="flex flex-1 flex-col">
         <TabsList className="w-full justify-start rounded-none border-b border-border bg-transparent px-6">
@@ -38,7 +39,7 @@ export function RequestEditor() {
 
         <TabsContent value="params" className="flex-1 overflow-auto p-6 mt-0">
           <KeyValueTable
-            items={request.queryParams}
+            items={queryParams}
             onAdd={addQueryParam}
             onUpdate={updateQueryParam}
             onDelete={removeQueryParam}
@@ -48,7 +49,7 @@ export function RequestEditor() {
 
         <TabsContent value="headers" className="flex-1 overflow-auto p-6 mt-0">
           <KeyValueTable
-            items={request.headers}
+            items={headers}
             onAdd={addHeader}
             onUpdate={updateHeader}
             onDelete={removeHeader}

--- a/packages/client/src/components/request-editor.tsx
+++ b/packages/client/src/components/request-editor.tsx
@@ -16,7 +16,7 @@ export function RequestEditor() {
   }
 
     const request = useAppStore((state) => state.request);
-    const body = useAppStore((state) => state.request.body);
+    const body = request.body;
     const setBody = useAppStore((state) => state.setBody);
 
     const addHeader = useAppStore((state) => state.addHeader);

--- a/packages/client/src/components/request-editor.tsx
+++ b/packages/client/src/components/request-editor.tsx
@@ -1,16 +1,9 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { KeyValueTable } from "@/components/key-value-table"
-import type { IRequestData } from "@proxymity/shared/src/types"
-
-
+import { useAppStore } from "@/store/useAppStore"
 import Editor, { type BeforeMount } from "@monaco-editor/react"
 
-interface RequestEditorProps {
-  request: IRequestData
-  onRequestChange: (request: IRequestData) => void
-}
-
-export function RequestEditor({ request, onRequestChange }: RequestEditorProps) {
+export function RequestEditor() {
     const handleEditorWillMount: BeforeMount = (monaco) => {
     monaco.editor.defineTheme('proxymity-dark', {
       base: 'vs-dark',
@@ -22,6 +15,17 @@ export function RequestEditor({ request, onRequestChange }: RequestEditorProps) 
     });
   }
 
+    const request = useAppStore((state) => state.request);
+    const body = useAppStore((state) => state.request.body);
+    const setBody = useAppStore((state) => state.setBody);
+
+    const addHeader = useAppStore((state) => state.addHeader);
+    const removeHeader = useAppStore((state) => state.removeHeader);
+    const updateHeader = useAppStore((state) => state.updateHeader);
+
+    const addQueryParam = useAppStore((state) => state.addQueryParam);
+    const removeQueryParam = useAppStore((state) => state.removeQueryParam);
+    const updateQueryParam = useAppStore((state) => state.updateQueryParam);
 
     return (
     <div className="flex h-full flex-col">
@@ -35,7 +39,9 @@ export function RequestEditor({ request, onRequestChange }: RequestEditorProps) 
         <TabsContent value="params" className="flex-1 overflow-auto p-6 mt-0">
           <KeyValueTable
             items={request.queryParams}
-            onChange={(queryParams) => onRequestChange({ ...request, queryParams })}
+            onAdd={addQueryParam}
+            onUpdate={updateQueryParam}
+            onDelete={removeQueryParam}
             placeholder="Query Parameter"
           />
         </TabsContent>
@@ -43,7 +49,9 @@ export function RequestEditor({ request, onRequestChange }: RequestEditorProps) 
         <TabsContent value="headers" className="flex-1 overflow-auto p-6 mt-0">
           <KeyValueTable
             items={request.headers}
-            onChange={(headers) => onRequestChange({ ...request, headers })}
+            onAdd={addHeader}
+            onUpdate={updateHeader}
+            onDelete={removeHeader}
             placeholder="Header"
           />
         </TabsContent>
@@ -55,9 +63,9 @@ export function RequestEditor({ request, onRequestChange }: RequestEditorProps) 
               <Editor
                 height="100%"
                 defaultLanguage="json"
-                defaultValue={request.body}
-                value={request.body}
-                onChange={(value) => onRequestChange({ ...request, body: value || "" })}
+                defaultValue={body}
+                value={body}
+                onChange={(value) => setBody(value || "")}
                 theme="proxymity-dark"
                 beforeMount={handleEditorWillMount}
                 options={{

--- a/packages/client/src/components/response-viewer.tsx
+++ b/packages/client/src/components/response-viewer.tsx
@@ -2,17 +2,14 @@ import { useState } from "react"
 import { Loader2, Copy, Check } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import type { IResponseData } from "@proxymity/shared/src/types"
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import { useAppStore } from "@/store/useAppStore"
 
-interface ResponseViewerProps {
-  response: IResponseData | null
-  isLoading: boolean
-}
-
-export function ResponseViewer({ response, isLoading }: ResponseViewerProps) {
+export function ResponseViewer() {
     const [isCopied, setIsCopied] = useState(false)
+    const isLoading = useAppStore((state) => state.isLoading);
+    const response = useAppStore((state) => state.response);
   
     if (isLoading) {
     return (


### PR DESCRIPTION
## 📋 Summary
This PR refactors the client-side state management by migrating request and response handling from local component state to a centralized global store using useAppStore. It also improves the API surface of the KeyValueTable component and enhances UI feedback during requests.

### Key Changes:
- Moved request/response state (including loading status) from `App.tsx `to `useAppStore`.
- Updated `RequestControls`, `RequestEditor`, and `ResponseViewer` to interact directly with the store, eliminating prop drilling.
- KeyValueTable Update: Replaced the single `onChange` prop with granular `onAdd`, `onUpdate`, and `onDelete` callbacks for better control.
- Added a `Loader2` spinner to the Send button in `RequestControls` to indicate active requests. Also increase the button width for consistency on both modes (it now does not grow when text change to "Sending").

## 🛠 Type of Change
- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [x] ♻️ **Refactor** (code change that neither fixes a bug nor adds a feature)
- [x] 🎨 **UI/UX** (visual changes in Shadcn/Tailwind)
- [x] ⚙️ **Config/Chore** (changes to package.json, CI/CD, tooling)

## 🔍 How was it tested?
1. Start the client (`pnpm dev` in client)
2. Navigate to the mainpage
3. Modify headers or params in the RequestEditor (verifies KeyValueTable new callbacks) and switch tabs/components to ensure data persists in the global store.
4. Click the "Send" button and verify that the spinner icon appears while the request is pending.
5. Verify that the response data is correctly displayed in ResponseViewer after the request completes.

## 📝 TODO / Pending Technical Debt
- [ ] Add unit tests for the new useAppStore slices to ensure state logic is robust.
- [ ] Verify if any residual local state in App.tsx can be further cleaned up

## ✅ Self-Review Checklist
- [ ] My changes generate no new **ESLint** warnings or **TypeScript** errors.
- [x] I have run `npx knip` and verified that I am not introducing unused dependencies or dead code.
- [x] I have updated the documentation (if applicable).