### PR TITLE
Feat/websocket frontend integration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,5 +25,5 @@
 
 ## ✅ Self-Review Checklist
 - [ ] My changes generate no new **ESLint** warnings or **TypeScript** errors.
-- [ ] I have run `npx knip` and verified that I am not introducing unused dependencies or dead code.
+- [ ] I have run `pnpm knip` and verified that I am not introducing unused dependencies or dead code.
 - [ ] I have updated the documentation (if applicable).

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,6 +24,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-syntax-highlighter": "^16.1.0",
+    "socket.io-client": "^4.8.3",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",
     "zustand": "^5.0.9"

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,104 +1,16 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { WorkspaceHeader } from "@/components/workspace-header"
 import { RequestControls } from "@/components/request-controls"
 import { RequestEditor } from "@/components/request-editor"
 import { ResponseViewer } from "@/components/response-viewer"
 import { useAppStore } from "@/store/useAppStore"
-import { socket } from "@/services/socket"
-import { SOCKET_EVENTS, IRoomState } from '@proxymity/shared';
+import { useRoomConnection } from "@/hooks/useRoomConnection"
 
 function App() {
   const [roomId] = useState<string>("example-room-id");
+  
+  const { sendRequest } = useRoomConnection(roomId);
   const activeUsers = useAppStore((state) => state.activeUsers);
-
-  const setResponse = useAppStore((state) => state.setResponse);
-  const setLoading = useAppStore((state) => state.setLoading);
-  const setRequest = useAppStore((state) => state.setRequest);
-  const setMethod = useAppStore((state) => state.setMethod);
-  const setUrl = useAppStore((state) => state.setUrl);
-  const setBody = useAppStore((state) => state.setBody);
-  const setActiveUsers = useAppStore((state) => state.setActiveUsers);
-  const setHeaders = useAppStore((state) => state.setHeaders);
-  const setQueryParams = useAppStore((state) => state.setQueryParams);
-
-  useEffect(() => {
-    const onConnect = () => {
-      console.log("Connected to socket server with ID:", socket.id);
-      socket.emit(SOCKET_EVENTS.CLIENT.JOIN_ROOM, roomId);
-    };
-
-    const onDisconnect = () => {
-      console.log("Disconnected from socket server");
-      socket.emit(SOCKET_EVENTS.CLIENT.LEAVE_ROOM, roomId);
-    };
-
-    const onSyncState = (roomState: IRoomState) => {
-      console.log("Received state from server:", roomState);
-      setRequest(roomState.request);
-    };
-
-    const onBroadcastChange = (updatedData: { field: string, value: any }) => {
-      console.log("Received broadcasted change:", updatedData);
-      switch (updatedData.field) {
-        case 'method': setMethod(updatedData.value); break;
-        case 'url': setUrl(updatedData.value); break;
-        case 'body': setBody(updatedData.value); break;
-        case 'headers': setHeaders(updatedData.value); break;
-        case 'queryParams': setQueryParams(updatedData.value); break;
-      }
-    };
-
-    const onRequestStarted = () => {
-      setLoading(true);
-    }
-
-    const onRequestComplete = (response: any) => {
-      setResponse(response);
-      setLoading(false);
-    }
-
-    // const onError = (errorMessage: string) => {
-    //   console.error("Socket error:", errorMessage);
-    // };
-
-    const onUserCount = (count: number) => {
-      setActiveUsers(count);
-    }
-
-    socket.on('connect', onConnect);
-    socket.on('disconnect', onDisconnect);
-    socket.on(SOCKET_EVENTS.SERVER.SYNC_STATE, onSyncState);
-    socket.on(SOCKET_EVENTS.SERVER.BROADCAST_CHANGE, onBroadcastChange);
-    socket.on(SOCKET_EVENTS.SERVER.REQUEST_STARTED, onRequestStarted);
-    socket.on(SOCKET_EVENTS.SERVER.REQUEST_COMPLETE, onRequestComplete);
-    // socket.on(SOCKET_EVENTS.SERVER.ERROR, onError);
-    socket.on(SOCKET_EVENTS.SERVER.USER_COUNT, onUserCount);
-    
-    if (socket.connected) {
-      onConnect();
-    } else {
-      socket.connect();
-    }
-
-    return () => {
-      socket.off('connect', onConnect);
-      socket.off('disconnect', onDisconnect);
-      socket.off(SOCKET_EVENTS.SERVER.SYNC_STATE, onSyncState);
-      socket.off(SOCKET_EVENTS.SERVER.BROADCAST_CHANGE, onBroadcastChange);
-      socket.off(SOCKET_EVENTS.SERVER.REQUEST_STARTED, onRequestStarted);
-      socket.off(SOCKET_EVENTS.SERVER.REQUEST_COMPLETE, onRequestComplete);
-      // socket.off(SOCKET_EVENTS.SERVER.ERROR, onError);
-      socket.off(SOCKET_EVENTS.SERVER.USER_COUNT, onUserCount);
-      socket.disconnect();
-    };
-  }, []);
-
-  const handleSendRequest = async () => {
-    const currentRequest = useAppStore.getState().request;
-    console.log("Sending request:", currentRequest);
-    socket.emit(SOCKET_EVENTS.CLIENT.EXECUTE_REQUEST, { roomId });
-  }
-
 
   return (
     <div className="flex h-screen flex-col bg-background">
@@ -107,7 +19,7 @@ function App() {
       <div className="flex flex-1 flex-col overflow-hidden">
         <RequestControls
           roomId={roomId}
-          onSend={handleSendRequest}
+          onSend={sendRequest}
         />
 
         <div className="flex flex-1 overflow-hidden">

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,42 +1,102 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { WorkspaceHeader } from "@/components/workspace-header"
 import { RequestControls } from "@/components/request-controls"
 import { RequestEditor } from "@/components/request-editor"
 import { ResponseViewer } from "@/components/response-viewer"
 import { useAppStore } from "@/store/useAppStore"
+import { socket } from "@/services/socket"
+import { SOCKET_EVENTS, IRoomState } from '@proxymity/shared';
 
 function App() {
   const [roomId] = useState<string>("example-room-id");
-  const [activeUsers] = useState<number>(3);
+  const activeUsers = useAppStore((state) => state.activeUsers);
 
   const setResponse = useAppStore((state) => state.setResponse);
   const setLoading = useAppStore((state) => state.setLoading);
+  const setRequest = useAppStore((state) => state.setRequest);
+  const setMethod = useAppStore((state) => state.setMethod);
+  const setUrl = useAppStore((state) => state.setUrl);
+  const setBody = useAppStore((state) => state.setBody);
+  const setActiveUsers = useAppStore((state) => state.setActiveUsers);
+  const setHeaders = useAppStore((state) => state.setHeaders);
+  const setQueryParams = useAppStore((state) => state.setQueryParams);
+
+  useEffect(() => {
+    const onConnect = () => {
+      console.log("Connected to socket server with ID:", socket.id);
+      socket.emit(SOCKET_EVENTS.CLIENT.JOIN_ROOM, roomId);
+    };
+
+    const onDisconnect = () => {
+      console.log("Disconnected from socket server");
+      socket.emit(SOCKET_EVENTS.CLIENT.LEAVE_ROOM, roomId);
+    };
+
+    const onSyncState = (roomState: IRoomState) => {
+      console.log("Received state from server:", roomState);
+      setRequest(roomState.request);
+    };
+
+    const onBroadcastChange = (updatedData: { field: string, value: any }) => {
+      console.log("Received broadcasted change:", updatedData);
+      switch (updatedData.field) {
+        case 'method': setMethod(updatedData.value); break;
+        case 'url': setUrl(updatedData.value); break;
+        case 'body': setBody(updatedData.value); break;
+        case 'headers': setHeaders(updatedData.value); break;
+        case 'queryParams': setQueryParams(updatedData.value); break;
+      }
+    };
+
+    const onRequestStarted = () => {
+      setLoading(true);
+    }
+
+    const onRequestComplete = (response: any) => {
+      setResponse(response);
+      setLoading(false);
+    }
+
+    // const onError = (errorMessage: string) => {
+    //   console.error("Socket error:", errorMessage);
+    // };
+
+    const onUserCount = (count: number) => {
+      setActiveUsers(count);
+    }
+
+    socket.on('connect', onConnect);
+    socket.on('disconnect', onDisconnect);
+    socket.on(SOCKET_EVENTS.SERVER.SYNC_STATE, onSyncState);
+    socket.on(SOCKET_EVENTS.SERVER.BROADCAST_CHANGE, onBroadcastChange);
+    socket.on(SOCKET_EVENTS.SERVER.REQUEST_STARTED, onRequestStarted);
+    socket.on(SOCKET_EVENTS.SERVER.REQUEST_COMPLETE, onRequestComplete);
+    // socket.on(SOCKET_EVENTS.SERVER.ERROR, onError);
+    socket.on(SOCKET_EVENTS.SERVER.USER_COUNT, onUserCount);
+    
+    if (socket.connected) {
+      onConnect();
+    } else {
+      socket.connect();
+    }
+
+    return () => {
+      socket.off('connect', onConnect);
+      socket.off('disconnect', onDisconnect);
+      socket.off(SOCKET_EVENTS.SERVER.SYNC_STATE, onSyncState);
+      socket.off(SOCKET_EVENTS.SERVER.BROADCAST_CHANGE, onBroadcastChange);
+      socket.off(SOCKET_EVENTS.SERVER.REQUEST_STARTED, onRequestStarted);
+      socket.off(SOCKET_EVENTS.SERVER.REQUEST_COMPLETE, onRequestComplete);
+      // socket.off(SOCKET_EVENTS.SERVER.ERROR, onError);
+      socket.off(SOCKET_EVENTS.SERVER.USER_COUNT, onUserCount);
+      socket.disconnect();
+    };
+  }, []);
 
   const handleSendRequest = async () => {
     const currentRequest = useAppStore.getState().request;
     console.log("Sending request:", currentRequest);
-    setLoading(true)
-    // Simulate API call
-    setTimeout(() => {
-      setResponse({
-        status: 200,
-        statusText: "OK",
-        data: {
-          users: [
-            { id: 1, name: "John Doe", email: "john@example.com" },
-            { id: 2, name: "Jane Smith", email: "jane@example.com" },
-          ],
-        },
-        headers: {
-          "content-type": "application/json",
-          "cache-control": "no-cache",
-        },
-        time: 145,
-        size: 2048,
-        timestamp: Date.now(),
-      })
-      setLoading(false)
-    }, 1000)
+    socket.emit(SOCKET_EVENTS.CLIENT.EXECUTE_REQUEST, { roomId });
   }
 
 
@@ -46,12 +106,15 @@ function App() {
 
       <div className="flex flex-1 flex-col overflow-hidden">
         <RequestControls
+          roomId={roomId}
           onSend={handleSendRequest}
         />
 
         <div className="flex flex-1 overflow-hidden">
           <div className="w-1/2 border-r border-border overflow-hidden">
-            <RequestEditor/>
+            <RequestEditor
+              roomId={roomId}
+            />
           </div>
 
           <div className="w-1/2 overflow-hidden">

--- a/packages/client/src/components/request-controls.tsx
+++ b/packages/client/src/components/request-controls.tsx
@@ -27,15 +27,25 @@ export function RequestControls({ roomId, onSend }: RequestControlsProps) {
   const setUrl = useAppStore((state) => state.setUrl);
   const setMethod = useAppStore((state) => state.setMethod);
 
+  const emitWithConnection = (event: string, data: any) => {
+    if (socket.connected) {
+      socket.emit(event, data);
+    } else {
+      socket.once('connect', () => {
+        socket.emit(event, data);
+      });
+    }
+  }
+
   const handleMethodChange = (newMethod: HttpMethod) => {
     setMethod(newMethod);
-    socket.emit(SOCKET_EVENTS.CLIENT.UPDATE_METHOD, { roomId, method: newMethod });
+    emitWithConnection(SOCKET_EVENTS.CLIENT.UPDATE_METHOD, { roomId, method: newMethod });
   }
 
   const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newUrl = e.target.value;
     setUrl(newUrl);
-    socket.emit(SOCKET_EVENTS.CLIENT.UPDATE_URL, { roomId, url: newUrl });
+    emitWithConnection(SOCKET_EVENTS.CLIENT.UPDATE_URL, { roomId, url: newUrl });
   }
 
   return (

--- a/packages/client/src/components/request-editor.tsx
+++ b/packages/client/src/components/request-editor.tsx
@@ -34,22 +34,32 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
   const removeQueryParam = useAppStore((state) => state.removeQueryParam);
   const updateQueryParam = useAppStore((state) => state.updateQueryParam);
 
+  const emitWithConnection = (event: string, data: any) => {
+    if (socket.connected) {
+      socket.emit(event, data);
+    } else {
+      socket.once('connect', () => {
+        socket.emit(event, data);
+      });
+    }
+  }
+
   const handleBodyChange = (newBody: string | undefined) => {
     const bodyContent = newBody || "";
     setBody(bodyContent);
-    socket.emit(SOCKET_EVENTS.CLIENT.UPDATE_BODY, { roomId, body: bodyContent });
+    emitWithConnection(SOCKET_EVENTS.CLIENT.UPDATE_BODY, { roomId, body: bodyContent });
   }
 
   const handleHeadersChange = (action: () => void) => {
     action();
     const updatedHeaders = useAppStore.getState().request.headers;
-    socket.emit(SOCKET_EVENTS.CLIENT.UPDATE_HEADERS, { roomId, headers: updatedHeaders });
+    emitWithConnection(SOCKET_EVENTS.CLIENT.UPDATE_HEADERS, { roomId, headers: updatedHeaders });
   }
 
   const handleParamsChange = (action: () => void) => {
     action();
     const updatedParams = useAppStore.getState().request.queryParams;
-    socket.emit(SOCKET_EVENTS.CLIENT.UPDATE_PARAMS, { roomId, queryParams: updatedParams });
+    emitWithConnection(SOCKET_EVENTS.CLIENT.UPDATE_PARAMS, { roomId, queryParams: updatedParams });
   }
 
   return (

--- a/packages/client/src/components/request-editor.tsx
+++ b/packages/client/src/components/request-editor.tsx
@@ -2,8 +2,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { KeyValueTable } from "@/components/key-value-table"
 import { useAppStore } from "@/store/useAppStore"
 import Editor, { type BeforeMount } from "@monaco-editor/react"
+import { socket } from "@/services/socket"
+import { SOCKET_EVENTS } from "@proxymity/shared"
 
-export function RequestEditor() {
+interface RequestEditorProps {
+  roomId: string;
+}
+
+export function RequestEditor({ roomId }: RequestEditorProps) {
   const handleEditorWillMount: BeforeMount = (monaco) => {
     monaco.editor.defineTheme('proxymity-dark', {
       base: 'vs-dark',
@@ -28,6 +34,24 @@ export function RequestEditor() {
   const removeQueryParam = useAppStore((state) => state.removeQueryParam);
   const updateQueryParam = useAppStore((state) => state.updateQueryParam);
 
+  const handleBodyChange = (newBody: string | undefined) => {
+    const bodyContent = newBody || "";
+    setBody(bodyContent);
+    socket.emit(SOCKET_EVENTS.CLIENT.UPDATE_BODY, { roomId, body: bodyContent });
+  }
+
+  const handleHeadersChange = (action: () => void) => {
+    action();
+    const updatedHeaders = useAppStore.getState().request.headers;
+    socket.emit(SOCKET_EVENTS.CLIENT.UPDATE_HEADERS, { roomId, headers: updatedHeaders });
+  }
+
+  const handleParamsChange = (action: () => void) => {
+    action();
+    const updatedParams = useAppStore.getState().request.queryParams;
+    socket.emit(SOCKET_EVENTS.CLIENT.UPDATE_PARAMS, { roomId, queryParams: updatedParams });
+  }
+
   return (
     <div className="flex h-full flex-col">
       <Tabs defaultValue="params" className="flex flex-1 flex-col">
@@ -40,9 +64,9 @@ export function RequestEditor() {
         <TabsContent value="params" className="flex-1 overflow-auto p-6 mt-0">
           <KeyValueTable
             items={queryParams}
-            onAdd={addQueryParam}
-            onUpdate={updateQueryParam}
-            onDelete={removeQueryParam}
+            onAdd={() => handleParamsChange(addQueryParam)}
+            onUpdate={(id, field, value) => handleParamsChange(() => updateQueryParam(id, field, value))}
+            onDelete={(id) => handleParamsChange(() => removeQueryParam(id))}
             placeholder="Query Parameter"
           />
         </TabsContent>
@@ -50,9 +74,9 @@ export function RequestEditor() {
         <TabsContent value="headers" className="flex-1 overflow-auto p-6 mt-0">
           <KeyValueTable
             items={headers}
-            onAdd={addHeader}
-            onUpdate={updateHeader}
-            onDelete={removeHeader}
+            onAdd={() => handleHeadersChange(addHeader)}
+            onUpdate={(id, field, value) => handleHeadersChange(() => updateHeader(id, field, value))}
+            onDelete={(id) => handleHeadersChange(() => removeHeader(id))}
             placeholder="Header"
           />
         </TabsContent>
@@ -66,7 +90,7 @@ export function RequestEditor() {
                 defaultLanguage="json"
                 defaultValue={body}
                 value={body}
-                onChange={(value) => setBody(value || "")}
+                onChange={handleBodyChange}
                 theme="proxymity-dark"
                 beforeMount={handleEditorWillMount}
                 options={{

--- a/packages/client/src/components/request-editor.tsx
+++ b/packages/client/src/components/request-editor.tsx
@@ -51,15 +51,23 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
   }
 
   const handleHeadersChange = (action: () => void) => {
-    action();
-    const updatedHeaders = useAppStore.getState().request.headers;
-    emitWithConnection(SOCKET_EVENTS.CLIENT.UPDATE_HEADERS, { roomId, headers: updatedHeaders });
+    try{ 
+      action();
+      const updatedHeaders = useAppStore.getState().request.headers;
+      emitWithConnection(SOCKET_EVENTS.CLIENT.UPDATE_HEADERS, { roomId, headers: updatedHeaders });
+    } catch (error) {
+      console.error("Failed to update headers and emit socket event:", error);
+    }
   }
 
   const handleParamsChange = (action: () => void) => {
-    action();
-    const updatedParams = useAppStore.getState().request.queryParams;
-    emitWithConnection(SOCKET_EVENTS.CLIENT.UPDATE_PARAMS, { roomId, queryParams: updatedParams });
+    try {
+      action();
+      const updatedParams = useAppStore.getState().request.queryParams;
+      emitWithConnection(SOCKET_EVENTS.CLIENT.UPDATE_PARAMS, { roomId, queryParams: updatedParams });
+    } catch (error) {
+      console.error("Failed to update query parameters and emit socket event:", error);
+    }
   }
 
   return (

--- a/packages/client/src/hooks/useRoomConnection.ts
+++ b/packages/client/src/hooks/useRoomConnection.ts
@@ -62,9 +62,7 @@ export const useRoomConnection = (roomId: string) => {
 
     if (socket.connected) {
       onConnect();
-    } else {
-      socket.connect();
-    }
+    } 
 
     return () => {
       socket.off('connect', onConnect);

--- a/packages/client/src/hooks/useRoomConnection.ts
+++ b/packages/client/src/hooks/useRoomConnection.ts
@@ -76,7 +76,7 @@ export const useRoomConnection = (roomId: string) => {
         socket.emit(SOCKET_EVENTS.CLIENT.LEAVE_ROOM, roomId);
       }
     };
-  }, []);
+  }, [roomId, setRequest, setMethod, setUrl, setBody, setHeaders, setQueryParams, setResponse, setLoading, setActiveUsers]);
 
   const sendRequest = () => {
     const currentRequest = useAppStore.getState().request;

--- a/packages/client/src/hooks/useRoomConnection.ts
+++ b/packages/client/src/hooks/useRoomConnection.ts
@@ -81,7 +81,8 @@ export const useRoomConnection = (roomId: string) => {
   const sendRequest = () => {
     const currentRequest = useAppStore.getState().request;
     console.log("Sending request:", currentRequest);
-    socket.emit(SOCKET_EVENTS.CLIENT.EXECUTE_REQUEST, roomId);
+    console.log(roomId);
+    socket.emit(SOCKET_EVENTS.CLIENT.EXECUTE_REQUEST, { roomId });
   };
 
   return { sendRequest };

--- a/packages/client/src/hooks/useRoomConnection.ts
+++ b/packages/client/src/hooks/useRoomConnection.ts
@@ -36,6 +36,9 @@ export const useRoomConnection = (roomId: string) => {
         case 'body': setBody(updatedData.value); break;
         case 'headers': setHeaders(updatedData.value); break;
         case 'queryParams': setQueryParams(updatedData.value); break;
+        default: 
+          console.warn(`Unknown field broadcasted from server: ${updatedData.field}`);
+          break;
       }
     };
 

--- a/packages/client/src/hooks/useRoomConnection.ts
+++ b/packages/client/src/hooks/useRoomConnection.ts
@@ -74,7 +74,9 @@ export const useRoomConnection = (roomId: string) => {
       socket.off(SOCKET_EVENTS.SERVER.REQUEST_STARTED, onRequestStarted);
       socket.off(SOCKET_EVENTS.SERVER.REQUEST_COMPLETE, onRequestComplete);
       socket.off(SOCKET_EVENTS.SERVER.USER_COUNT, onUserCount);
-      socket.disconnect();
+      if (socket.connected) {
+        socket.emit(SOCKET_EVENTS.CLIENT.LEAVE_ROOM, roomId);
+      }
     };
   }, []);
 

--- a/packages/client/src/hooks/useRoomConnection.ts
+++ b/packages/client/src/hooks/useRoomConnection.ts
@@ -1,0 +1,88 @@
+import { useEffect } from "react";
+import { socket } from "@/services/socket";
+import { SOCKET_EVENTS, IRoomState } from '@proxymity/shared';
+import { useAppStore } from "@/store/useAppStore";
+
+export const useRoomConnection = (roomId: string) => {
+  const setResponse = useAppStore((state) => state.setResponse);
+  const setLoading = useAppStore((state) => state.setLoading);
+  const setRequest = useAppStore((state) => state.setRequest);
+  const setMethod = useAppStore((state) => state.setMethod);
+  const setUrl = useAppStore((state) => state.setUrl);
+  const setBody = useAppStore((state) => state.setBody);
+  const setActiveUsers = useAppStore((state) => state.setActiveUsers);
+  const setHeaders = useAppStore((state) => state.setHeaders);
+  const setQueryParams = useAppStore((state) => state.setQueryParams);
+
+  useEffect(() => {
+    const onConnect = () => {
+      socket.emit(SOCKET_EVENTS.CLIENT.JOIN_ROOM, roomId);
+    };
+
+    const onDisconnect = () => {
+      socket.emit(SOCKET_EVENTS.CLIENT.LEAVE_ROOM, roomId);
+    };
+
+    const onSyncState = (roomState: IRoomState) => {
+      console.log("Received state from server:", roomState);
+      setRequest(roomState.request);
+    };
+
+    const onBroadcastChange = (updatedData: { field: string, value: any }) => {
+      console.log("Received broadcasted change:", updatedData);
+      switch (updatedData.field) {
+        case 'method': setMethod(updatedData.value); break;
+        case 'url': setUrl(updatedData.value); break;
+        case 'body': setBody(updatedData.value); break;
+        case 'headers': setHeaders(updatedData.value); break;
+        case 'queryParams': setQueryParams(updatedData.value); break;
+      }
+    };
+
+    const onRequestStarted = () => {
+      setLoading(true);
+    }
+
+    const onRequestComplete = (response: any) => {
+      setResponse(response);
+      setLoading(false);
+    }
+
+    const onUserCount = (count: number) => {
+      setActiveUsers(count);
+    }
+
+    socket.on('connect', onConnect);
+    socket.on('disconnect', onDisconnect);
+    socket.on(SOCKET_EVENTS.SERVER.SYNC_STATE, onSyncState);
+    socket.on(SOCKET_EVENTS.SERVER.BROADCAST_CHANGE, onBroadcastChange);
+    socket.on(SOCKET_EVENTS.SERVER.REQUEST_STARTED, onRequestStarted);
+    socket.on(SOCKET_EVENTS.SERVER.REQUEST_COMPLETE, onRequestComplete);
+    socket.on(SOCKET_EVENTS.SERVER.USER_COUNT, onUserCount);
+
+    if (socket.connected) {
+      onConnect();
+    } else {
+      socket.connect();
+    }
+
+    return () => {
+      socket.off('connect', onConnect);
+      socket.off('disconnect', onDisconnect);
+      socket.off(SOCKET_EVENTS.SERVER.SYNC_STATE, onSyncState);
+      socket.off(SOCKET_EVENTS.SERVER.BROADCAST_CHANGE, onBroadcastChange);
+      socket.off(SOCKET_EVENTS.SERVER.REQUEST_STARTED, onRequestStarted);
+      socket.off(SOCKET_EVENTS.SERVER.REQUEST_COMPLETE, onRequestComplete);
+      socket.off(SOCKET_EVENTS.SERVER.USER_COUNT, onUserCount);
+      socket.disconnect();
+    };
+  }, []);
+
+  const sendRequest = () => {
+    const currentRequest = useAppStore.getState().request;
+    console.log("Sending request:", currentRequest);
+    socket.emit(SOCKET_EVENTS.CLIENT.EXECUTE_REQUEST, roomId);
+  };
+
+  return { sendRequest };
+};

--- a/packages/client/src/services/socket.ts
+++ b/packages/client/src/services/socket.ts
@@ -1,0 +1,7 @@
+import { io } from 'socket.io-client';
+
+const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || 'http://localhost:3001';
+
+export const socket = io(SOCKET_URL, {
+  autoConnect: true,
+});

--- a/packages/client/src/store/useAppStore.ts
+++ b/packages/client/src/store/useAppStore.ts
@@ -8,6 +8,7 @@ interface AppState {
   request: IRequestData;
   response: IResponseData | null;
   isLoading: boolean;
+  activeUsers: number;
 
   // Basic Actions
   setMethod: (method: HttpMethod) => void;
@@ -16,6 +17,9 @@ interface AppState {
   setResponse: (response: IResponseData | null) => void;
   setLoading: (isLoading: boolean) => void;
   setRequest: (newRequest: IRequestData) => void;
+  setActiveUsers: (count: number) => void;
+  setHeaders: (headers: IKeyValue[]) => void;
+  setQueryParams: (queryParams: IKeyValue[]) => void;
 
   // Header Actions
   addHeader: () => void;
@@ -39,6 +43,7 @@ export const useAppStore = create<AppState>()((set) => ({
   },
   response: null,
   isLoading: false,
+  activeUsers: 0,
 
   setMethod: (method) =>
     set((state) => ({ request: { ...state.request, method } })),
@@ -52,6 +57,14 @@ export const useAppStore = create<AppState>()((set) => ({
   setResponse: (response) => set({ response }),
   setLoading: (isLoading) => set({ isLoading }),
   setRequest: (newRequest) => set({ request: newRequest }),
+  setActiveUsers: (count) => set({ activeUsers: count }),
+
+  setHeaders: (headers) =>
+    set((state) => ({ request: { ...state.request, headers } })),
+
+  setQueryParams: (queryParams) =>
+    set((state) => ({ request: { ...state.request, queryParams } })),
+
 
   addHeader: () => set((state) => ({
     request: { ...state.request,

--- a/packages/client/src/vite-env.d.ts
+++ b/packages/client/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/server/src/handlers/room-handler.ts
+++ b/packages/server/src/handlers/room-handler.ts
@@ -130,8 +130,8 @@ export const registerRoomHandlers = (io: Server, socket: Socket) => {
     handleUpdateHeaders(socket, roomId, headers);
   });
 
-  socket.on(SOCKET_EVENTS.CLIENT.UPDATE_PARAMS, ({ roomId, params }) => {
-    handleUpdateParams(socket, roomId, params);
+  socket.on(SOCKET_EVENTS.CLIENT.UPDATE_PARAMS, ({ roomId, queryParams }) => {
+    handleUpdateParams(socket, roomId, queryParams);
   });
 
   socket.on(SOCKET_EVENTS.CLIENT.UPDATE_BODY, ({ roomId, body }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       react-syntax-highlighter:
         specifier: ^16.1.0
         version: 16.1.0(react@19.2.3)
+      socket.io-client:
+        specifier: ^4.8.3
+        version: 4.8.3
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -1557,6 +1560,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  engine.io-client@6.6.4:
+    resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
+
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
@@ -2391,6 +2397,10 @@ packages:
   socket.io-adapter@2.5.5:
     resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
 
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
   socket.io-parser@4.2.4:
     resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
     engines: {node: '>=10.0.0'}
@@ -2639,6 +2649,22 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3971,6 +3997,18 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  engine.io-client@6.6.4:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3(supports-color@5.5.0)
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   engine.io-parser@5.2.3: {}
 
   engine.io@6.6.4:
@@ -4884,6 +4922,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3(supports-color@5.5.0)
+      engine.io-client: 6.6.4
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socket.io-parser@4.2.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -5081,6 +5130,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.17.1: {}
+
+  ws@8.18.3: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## 📋 Summary
This PR implements real-time collaborative editing for the API request builder using socket.io. It enables multiple users to join the same workspace room and see live updates to the request editor (URL, method, headers, query params, and body) and execution results.

Key technical changes include:
- Client-Side: Integration of socket.io-client, creation of a dedicated useRoomConnection hook to abstract socket logic, and refactoring of RequestControls and RequestEditor to emit/listen to broadcast events.
- State Management: Updated useAppStore (Zustand) to handle full-list updates for headers/params and track activeUsers.
- Server-Side: Fix in room-handler to correctly map queryParams during synchronization.

## 🛠 Type of Change
- [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [x] ♻️ **Refactor** (code change that neither fixes a bug nor adds a feature)
- [ ] 🎨 **UI/UX** (visual changes in Shadcn/Tailwind)
- [x] ⚙️ **Config/Chore** (changes to package.json, CI/CD, tooling)

## 🔍 How was it tested?
1. Start the server (`pnpm dev` in `packages/server`) and client (`pnpm dev` in `packages/client`).
2. Open the applicacion in two different browser tabs (simulating two users).
3. Verify by console that both clients are connected to the server and the same room (`example-room-id`by default).
4. Change the Url, HTTP Method, headers, queryParams and Body in Tab A and verify if Tab B updated the fiels instantly, and viceversa.
5. Click "Send" in one tab and verify both tabs show the loading state and receibe the same response simultaneously.

## 📸 Visual Evidence (Optional)
| Before | After |
|--------|-------|
| N/A | N/A |

## 📝 TODO / Pending Technical Debt
- [ ] Remove the hardcoded `example-room-id` in `App.tsx` and implement dynamic routing to support multiple rooms.
- [ ] Add visual indicators (avatar and cursors) to show who is making changes
- [ ] Improve UI feedback for socket disconnection/reconnection scenarios.

## ✅ Self-Review Checklist
- [x] My changes generate no new **ESLint** warnings or **TypeScript** errors.
- [x] I have run `npx knip` and verified that I am not introducing unused dependencies or dead code.
- [x] I have updated the documentation (if applicable).