### PR TITLE
feat: Add GitHub Actions workflow to send notifications when a pull r…

### DIFF
--- a/.github/workflows/proxito.yml
+++ b/.github/workflows/proxito.yml
@@ -1,0 +1,54 @@
+name: Notificaciones de Proxito
+on:
+  pull_request:
+    types: [review_requested]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enviar Notificación
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          ACTOR: ${{ github.actor }}
+          REVIEWER_LOGIN: ${{ github.event.requested_reviewer.login }}
+          TEAM_REVIEWER: ${{ github.event.requested_team.name }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          # Determine the reviewer name (user or team)
+          REVIEWER="${REVIEWER_LOGIN:-${TEAM_REVIEWER:-Unknown}}"
+
+          # Construct the JSON payload safely using jq to avoid injection vulnerabilities
+          jq -n \
+            --arg actor "$ACTOR" \
+            --arg pr_url "$PR_URL" \
+            --arg reviewer "$REVIEWER" \
+            --arg pr_title "$PR_TITLE" \
+            '{
+              embeds: [{
+                title: "🚀 ¡Solicitud de revisión para Proxymity!",
+                description: ("¡Hola! He detectado cambios en el código y **" + $actor + "** necesita tu ayuda para revisarlos. \n\n¿Podrías echarle un vistazo para que todo siga funcionando perfecto? ✨"),
+                url: $pr_url,
+                color: 15105570,
+                fields: [
+                  {
+                    name: "🧸 Revisor",
+                    value: ("`" + $reviewer + "`"),
+                    inline: true
+                  },
+                  {
+                    name: "📑 Pull Request",
+                    value: $pr_title,
+                    inline: true
+                  }
+                ],
+                footer: {
+                  text: "Proxito está cuidando de la sala de Proxymity",
+                  "icon_url": "https://em-content.zobj.net/source/apple/391/sparkles_2728.png"
+                }
+              }]
+            }' > payload.json
+
+          # Send the notification, failing if the request fails
+          curl --fail -H "Content-Type: application/json" -d @payload.json "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## 📋 Summary
Added a new GitHub Actions workflow, `proxito.yml`, to send automated notifications to Discord whenever a Pull Request review is requested. This improves team communication by alerting reviewers promptly.

## 🛠 Type of Change
- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] ♻️ **Refactor** (code change that neither fixes a bug nor adds a feature)
- [ ] 🎨 **UI/UX** (visual changes in Shadcn/Tailwind)
- [x] ⚙️ **Config/Chore** (changes to package.json, CI/CD, tooling)

## 🔍 How was it tested?
1. Open a Pull Request in the repository.
2. Request a review from a team member.
3. Verify that the GitHub Action `Notificaciones de Proxito` runs successfully.
4. Confirm that a formatted message with the PR details appears in the configured Discord channel.

## 📸 Visual Evidence (Optional)
| Before | After |
|--------|-------|
| No automated notifications | Discord notification with PR title, requester, and reviewer link |

## 📝 TODO / Pending Technical Debt
- [ ] Ensure `DISCORD_WEBHOOK_URL` secret is configured in the repository settings.

## ✅ Self-Review Checklist
- [x] My changes generate no new **ESLint** warnings or **TypeScript** errors.
- [x] I have run `pnpm knip` and verified that I am not introducing unused dependencies or dead code.
- [x] I have updated the documentation (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Discord notifications when pull request reviews are requested, improving team communication and review visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->