### PR TITLE
chore: add Claude Code project configuration and skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "plugins": [
+    "claude-plugins-official/code-review",
+    "claude-plugins-official/typescript-lsp",
+    "claude-plugins-official/feature-dev",
+    "claude-plugins-official/frontend-design",
+    "claude-plugins-official/security-guidance",
+    "claude-plugins-official/skill-creator"
+  ],
+  "permissions": {
+        "deny": [
+            "Read(.env)",
+            "Read(.env.*)",
+            "Read(**/env)",
+            "Read(**/env.*)",
+            "Read(node_modules)",
+            "Read(**/node_modules)",
+            "Read(**/node_modules/**)",
+            "Bash(rm -rf *)",
+            "Bash(git push --force)",
+            "Bash(git reset --hard)"
+        ]
+    }
+}

--- a/.claude/skills/code-health/SKILL.md
+++ b/.claude/skills/code-health/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: code-health
+description: Audita el repositorio buscando code smells, dead code, complejidad innecesaria y problemas de rendimiento, con hallazgos priorizados y accionables. Úsalo para revisar calidad de código, deuda técnica, o cuando el usuario diga "revisa el código", "qué tan sano está el proyecto", o mencione un área específica a analizar.
+---
+
+# Code Health
+
+Audita la salud del código fuente. Objetivo: hallazgos específicos y accionables, no observaciones genéricas.
+
+## Paso 0: Determinar alcance
+
+Si el usuario menciona un área específica, limitar el análisis a esa área. Si no especifica, analizar el repositorio completo.
+
+## Proceso
+
+1. **Leer CLAUDE.md** para entender las convenciones del proyecto antes de evaluar consistencia.
+
+2. **Ejecutar herramientas de análisis estático** — datos objetivos antes del análisis manual:
+   ```bash
+   pnpm knip                            # código muerto y dependencias sin usar
+   pnpm --filter @proxymity/client lint # problemas de ESLint
+   ```
+
+3. **Escanear el código** buscando:
+
+   | Categoría | Qué buscar |
+   |-----------|------------|
+   | Code smells | Funciones largas (>50 líneas), archivos con demasiadas responsabilidades, código duplicado, nesting excesivo (>3 niveles), nombres ambiguos |
+   | Clean Code | Funciones con múltiples responsabilidades, mezcla de niveles de abstracción, side effects ocultos, flag arguments, funciones con >3 parámetros |
+   | Código muerto | Exports no importados, funciones no llamadas, variables asignadas pero no leídas (complementar con knip) |
+   | Complejidad | Lógica condicional enredada, abstracciones prematuras o insuficientes, acoplamiento alto entre módulos |
+   | Rendimiento | Re-renders innecesarios en React, subscripciones demasiado amplias en Zustand, listeners de WebSocket que no se limpian, operaciones síncronas costosas en el render path |
+   | Consistencia | Patrones mixtos para lo mismo, convenciones rotas respecto a CLAUDE.md |
+   | Tipado | Uso de `any`, type assertions innecesarias, tipos que deberían estar en `shared` pero están locales |
+
+4. **Priorizar** los hallazgos más impactantes:
+   - **Alta**: Bugs potenciales, problemas de rendimiento medibles, código que bloquea agregar funcionalidad nueva
+   - **Media**: Code smells que aumentan deuda técnica, inconsistencias que confunden
+   - **Baja**: Mejoras cosméticas, refactors de conveniencia
+
+   Si hay más de 10 hallazgos, reportar los 8 más críticos: *"Encontré X en total. Aquí los 8 más críticos — ¿quieres ver el resto?"*
+
+5. **Presentar cada hallazgo**:
+
+   ### [Categoría] Nombre del hallazgo
+   **Severidad**: Alta / Media / Baja
+   **Ubicación**: `archivo:línea`
+   **Problema**: Qué se detectó y por qué importa.
+   **Sugerencia**: Acción concreta, con ejemplo de código si aplica.
+   **Esfuerzo**: Trivial / Pequeño / Moderado
+   **Principio violado**: (solo para categorías Clean Code y Tipado — omitir en Rendimiento, Código muerto, Consistencia)
+
+6. **Resumen final**: conteo por severidad, top 3 acciones recomendadas, qué está bien.
+
+7. **Ofrecer siguiente paso**: ¿convertir hallazgos en issues con `/create-issue`? ¿aplicar alguna corrección directamente?
+
+## Reglas
+
+- No reportar falsos positivos. Si no estás seguro, no lo incluyas.
+- No sugerir refactors que cambien la API pública o el contrato de WebSocket sin advertirlo explícitamente.
+- Considerar el tamaño del proyecto — no aplicar estándares de enterprise a un proyecto pequeño.
+- Ser específico: "esta función en este archivo", nunca "el código podría mejorar".
+- No sugerir agregar herramientas o librerías salvo que resuelva un problema concreto encontrado.
+- No aplicar ningún cambio sin confirmación explícita.

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: create-issue
+description: Crea GitHub Issues en el Project board con prioridad y tamaño predefinidos. Úsalo cuando el usuario quiera registrar hallazgos de /code-health o /design-advisor, reportar bugs, o añadir cualquier tarea al backlog.
+disable-model-invocation: true
+---
+
+# Create Issue
+
+Genera issues en GitHub a partir de hallazgos de `/code-health`, `/design-advisor`, bugs reportados, o cualquier tarea identificada en la conversación. Las coloca en el Backlog del Project board con campos completos.
+
+## Contexto del proyecto
+
+- **Repo**: `Proxymity-org/proxymity`
+- **Project number**: `1`
+- **Project ID**: `PVT_kwDOD5bfyc4BSQNN`
+- **Status field ID**: `PVTSSF_lADOD5bfyc4BSQNNzg_16H0`
+- **Backlog option ID**: `f75ad846`
+- **Priority field ID**: `PVTSSF_lADOD5bfyc4BSQNNzg_16NI`
+- **Priority options**: High (`79628723`), Medium (`0a877460`), Low (`da944a9c`)
+- **Size field ID**: `PVTSSF_lADOD5bfyc4BSQNNzg_16NM`
+- **Size options**: XS (`6c6483d2`), S (`f784b110`), M (`7515a9f1`), L (`817d0097`), XL (`db339eb2`)
+
+## Labels disponibles
+
+| Label | Uso |
+|-------|-----|
+| `code-health` | Hallazgos del skill code-health |
+| `design-decision` | Decisiones del skill design-advisor |
+| `refactor` | Refactorización de código |
+| `performance` | Mejoras de rendimiento |
+| `tech-debt` | Deuda técnica |
+| `clean-code` | Violaciones de principios Clean Code |
+| `bug` | Bugs encontrados |
+| `enhancement` | Features o mejoras nuevas |
+
+## Proceso
+
+### 1. Determinar origen
+
+- **Contexto previo de skills**: Si hay hallazgos de `/code-health` o `/design-advisor` en la conversación, usarlos. Si son varios, presentar la lista y preguntar cuáles convertir.
+- **Descripción manual**: Si el usuario describe un bug o tarea directamente, usar esa información.
+- **Sin contexto**: Pedir que describa el hallazgo o que ejecute primero `/code-health` o `/design-advisor`.
+
+### 2. Mapear severidad a campos del Project
+
+| Origen / Severidad | Priority | Size sugerido |
+|--------------------|----------|---------------|
+| code-health: Alta | High | M o L |
+| code-health: Media | Medium | S o M |
+| code-health: Baja | Low | XS o S |
+| design-advisor | Medium | M |
+| Bug manual | High | S a M |
+| Enhancement | Medium | S a L |
+
+El usuario puede ajustar antes de crear.
+
+### 3. Seleccionar labels
+
+- **Origen**: `code-health`, `design-decision`, `bug`, o `enhancement`
+- **Categoría adicional**: `refactor`, `performance`, `tech-debt`, `clean-code` si aplica
+
+Máximo 3 labels por issue.
+
+### 4. Presentar preview y esperar confirmación
+
+Mostrar un resumen por issue antes de crear:
+
+```
+Issue 1: [Título accionable]
+Labels: code-health, refactor
+Priority: Medium | Size: S
+
+Issue 2: [Título accionable]
+Labels: design-decision
+Priority: Medium | Size: M
+```
+
+**No crear sin confirmación explícita.**
+
+### 5. Crear las issues
+
+Para cada issue confirmada:
+
+**a) Buscar duplicadas**:
+```bash
+gh issue list --repo Proxymity-org/proxymity --search "<términos clave>" --state all
+```
+Si existe una similar abierta, advertir y pedir confirmación. Si está cerrada, mencionarlo como contexto.
+
+**c) Crear la issue y capturar la URL en el mismo paso**:
+```bash
+ISSUE_URL=$(gh issue create \
+  --repo Proxymity-org/proxymity \
+  --title "Verbo + descripción accionable" \
+  --label "label1,label2" \
+  --body "$(cat <<'EOF'
+## Contexto
+
+[Origen del hallazgo]
+
+## Problema
+
+[Descripción clara del problema o decisión pendiente]
+
+## Ubicación
+
+[Archivos y líneas afectadas, si aplica]
+
+## Propuesta
+
+[Acción concreta sugerida]
+
+## Criterios de aceptación
+
+- [ ] [Criterio específico y verificable]
+- [ ] Tests pasan / Sin regresiones (omitir si es design-decision o docs)
+
+## Notas
+
+- **Principio violado**: [si aplica]
+- **Esfuerzo estimado**: Trivial / Pequeño / Moderado
+EOF
+)")
+```
+
+**d) Agregar al Project con la URL capturada**:
+```bash
+ITEM_ID=$(gh project item-add 1 --owner Proxymity-org --url "$ISSUE_URL" --format json | jq -r '.id')
+
+if [ -z "$ITEM_ID" ]; then
+  echo "Issue creada ($ISSUE_URL) pero no se pudo agregar al Project. Hacerlo manualmente."
+else
+  gh project item-edit --project-id PVT_kwDOD5bfyc4BSQNN --id $ITEM_ID \
+    --field-id PVTSSF_lADOD5bfyc4BSQNNzg_16H0 --single-select-option-id f75ad846
+
+  gh project item-edit --project-id PVT_kwDOD5bfyc4BSQNN --id $ITEM_ID \
+    --field-id PVTSSF_lADOD5bfyc4BSQNNzg_16NI --single-select-option-id <priority-option-id>
+
+  gh project item-edit --project-id PVT_kwDOD5bfyc4BSQNN --id $ITEM_ID \
+    --field-id PVTSSF_lADOD5bfyc4BSQNNzg_16NM --single-select-option-id <size-option-id>
+fi
+```
+
+### 6. Reportar resultado
+
+| # | Issue | Priority | Size | Labels | Project |
+|---|-------|----------|------|--------|---------|
+| 1 | [título](url) | Medium | S | code-health, refactor | ✓ Backlog |
+
+Si alguna issue no se pudo agregar al Project, indicarlo para que el usuario lo haga manualmente.
+
+## Reglas
+
+- **Nunca crear issues sin confirmación.**
+- Una issue por hallazgo. No agrupar.
+- Título accionable, empieza con verbo: "Extraer...", "Resolver...", "Decidir...", "Optimizar...".
+- No crear duplicadas. Siempre buscar antes (estados `open` y `closed`).
+- Criterios de aceptación verificables, no vagos.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: create-pr
+description: Crea un Pull Request completo: genera el branch, analiza el diff contra main y rellena la descripción con la template del repo. Úsalo cuando el usuario diga "crea un PR", "sube los cambios", "abre un pull request", o quiera enviar una feature o fix a revisión.
+disable-model-invocation: true
+---
+
+# Create PR
+
+Crea un Pull Request completo: genera el branch si no existe, analiza el diff contra main, rellena la template del repo y vincula la issue. Opcionalmente mueve la tarjeta del Project a "In review".
+
+## Convenciones del repo
+
+- **Branch**: `type/descripcion-kebab-case`
+- **PR title**: igual que el branch pero guiones → espacios (ej: `feat/websocket-frontend-integration` → `feat/websocket frontend integration`)
+- **Tipos**: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `perf`
+- **Commits**: una línea, `type: descripción corta`. Sin body ni co-authored-by.
+
+## Proceso
+
+### 1. Recopilar contexto
+
+```bash
+git status
+git log main..HEAD --oneline
+git diff main...HEAD --stat
+```
+
+- Sin commits sobre main → avisar que no hay cambios.
+- Con cambios sin commitear → preguntar si quiere commitearlos primero.
+- Con issue asociada: tomar el número de la conversación o preguntar.
+
+Obtener el diff completo para entender qué cambió y por qué:
+```bash
+git diff main...HEAD
+```
+
+### 2. Determinar branch y tipo
+
+**En un branch existente**: usarlo. Verificar si ya tiene PR abierto:
+```bash
+gh pr list --head <branch> --repo Proxymity-org/proxymity
+```
+Si ya existe un PR, mostrar la URL y preguntar si quiere actualizarlo o crear uno nuevo.
+
+**En main**: determinar el tipo por los cambios, generar `type/descripcion-kebab-case` y crear el branch.
+
+### 3. Verificar calidad
+
+```bash
+pnpm --filter @proxymity/client lint
+pnpm knip
+```
+
+Reportar errores si los hay. Preguntar si quiere continuar de todas formas — a veces se crea el PR con errores pendientes intencionalmente.
+
+### 4. Rellenar la descripción del PR
+
+Verificar si existe `.github/pull_request_template.md` y leerla. Si no existe, usar esta estructura base:
+
+```markdown
+## 📋 Summary
+- [qué cambió y por qué]
+- Closes #<number> (si hay issue)
+
+## 🛠 Type of Change
+- [ ] 🐛 Bug fix  - [ ] ✨ New feature  - [ ] ♻️ Refactor  - [ ] ⚙️ Config / Chore  - [ ] 📄 Docs
+
+## 🔍 How was it tested?
+1. [pasos específicos según los archivos cambiados]
+
+## 📸 Visual Evidence
+| Before | After |
+|--------|-------|
+|  |  |
+
+## 📝 Pending Technical Debt
+[TODOs en el diff, si los hay]
+```
+
+Completar cada sección con el diff real:
+- **Testing**: pasos específicos según qué paquete cambió (`client/` → browser, `server/` → requests/WebSocket, `shared/` → compilación)
+- **Visual Evidence / Pending Technical Debt**: omitir la sección si no aplica
+
+### 5. Presentar preview y esperar confirmación
+
+```
+Branch: feat/descripcion-feature
+Title:  feat/descripcion feature
+Closes: #12
+---
+[body completo]
+```
+
+### 6. Crear el PR
+
+```bash
+# Push — manejar el caso de que el branch ya exista en el remoto
+if git ls-remote --exit-code origin <branch-name> > /dev/null 2>&1; then
+  git push origin <branch-name>
+else
+  git push -u origin <branch-name>
+fi
+
+gh pr create \
+  --repo Proxymity-org/proxymity \
+  --base main \
+  --head <branch-name> \
+  --title "<título>" \
+  --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+### 7. Actualizar el Project (si hay issue vinculada)
+
+Usar el número de issue identificado en el paso 1. Si no se registró en ese momento, buscarlo en la conversación o en el `Closes #N` del body del PR antes de continuar.
+
+```bash
+ITEM_ID=$(gh project item-list 1 --owner Proxymity-org --format json \
+  | jq -r '.items[] | select(.content.number == <issue-number>) | .id')
+
+if [ -n "$ITEM_ID" ]; then
+  gh project item-edit --project-id PVT_kwDOD5bfyc4BSQNN --id $ITEM_ID \
+    --field-id PVTSSF_lADOD5bfyc4BSQNNzg_16H0 --single-select-option-id df73e18b
+fi
+```
+
+### 8. Reportar resultado
+
+```
+✓ PR creada: <url>
+  Branch: <branch> → main
+  Issue: Closes #<number> (movida a "In review")
+```
+
+## Reglas
+
+- Nunca crear el PR sin confirmación.
+- Nunca push a main directamente.
+- El body se genera del diff real. Si algo no es claro, preguntar.
+- No inventar pasos de testing — cada paso debe ser verificable con los cambios reales.
+- Si el diff es >500 líneas y no hay una razón clara que justifique el tamaño (feature XL, scaffolding inicial, migración masiva, refactor global), sugerir dividir en PRs más pequeños.

--- a/.claude/skills/design-advisor/SKILL.md
+++ b/.claude/skills/design-advisor/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: design-advisor
+description: Identifica decisiones de diseño pendientes y presenta alternativas con pros y contras. Úsalo cuando el usuario quiera evaluar opciones técnicas, pregunte "cómo deberíamos hacer X", "qué nos falta definir", o pida consejo sobre arquitectura o dirección técnica del proyecto.
+---
+
+# Design Advisor
+
+Analiza el estado actual del proyecto, detecta decisiones de diseño abiertas o implícitas, y presenta alternativas con pros/contras para que el usuario tome decisiones informadas.
+
+## Paso 0: Determinar alcance
+
+Si el usuario pregunta sobre algo específico, enfocar el análisis ahí. Si no hay tema concreto, hacer un análisis general buscando decisiones abiertas.
+
+## Proceso
+
+1. **Revisar CLAUDE.md** para identificar decisiones ya documentadas y no repetirlas.
+
+2. **Analizar el código** buscando señales de decisiones pendientes:
+   - Valores hardcodeados que deberían ser configurables
+   - TODOs, FIXMEs o comentarios que indiquen decisiones diferidas
+   - Patrones de implementación que no escalan
+   - Funcionalidad ausente pero esperable para este tipo de aplicación
+   - Oportunidades de mejora arquitectónica
+
+3. **Priorizar** por impacto:
+   - **Críticas**: Bloquean funcionalidad core o afectan usuarios hoy
+   - **Importantes**: Mejoran la arquitectura a mediano plazo
+   - **Nice-to-have**: Mejoras incrementales sin urgencia
+
+4. **Presentar cada decisión**:
+
+   ### [Nombre de la decisión]
+   **Contexto**: qué se detectó en el código y por qué importa decidir esto.
+   **Estado actual**: cómo está resuelto hoy, o que no está resuelto.
+
+   | Alternativa | Pros | Contras |
+   |-------------|------|---------|
+   | Opción A | ... | ... |
+   | Opción B | ... | ... |
+
+   **Recomendación**: cuál elegiría y por qué, considerando el tamaño y etapa actual del proyecto.
+
+5. **Esperar la decisión del usuario** sobre cada punto.
+
+6. **Después de cada decisión**, preguntar qué sigue:
+   - **Implementar ahora** → ofrecer usar `/feature-dev`
+   - **Guardar en backlog** → ofrecer crear una issue con `/create-issue`
+   - **Solo documentar** → proponer agregar a CLAUDE.md con este formato:
+
+     ```markdown
+     ## Decisiones de diseño
+
+     | Decisión | Opción elegida | Razón | Fecha |
+     |----------|---------------|-------|-------|
+     | [nombre] | [opción] | [por qué] | [mes/año] |
+     ```
+
+     Pedir confirmación antes de modificar CLAUDE.md.
+
+## Reglas
+
+- Máximo 5 decisiones por invocación. Priorizar las más impactantes.
+- Ser honesto sobre trade-offs. No favorecer complejidad por ser "mejor práctica".
+- No sobre-ingenierar. Considerar el tamaño del equipo y la etapa del proyecto.
+- Si el usuario pide profundizar en algo, dar más detalle técnico con ejemplos de código.
+- No implementar nada sin confirmación explícita.

--- a/.claude/skills/sync-claude-md/SKILL.md
+++ b/.claude/skills/sync-claude-md/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: sync-claude-md
+description: Audita CLAUDE.md contra el código actual y propone correcciones donde haya discrepancias. Úsalo después de features o refactors significativos, o cuando CLAUDE.md pueda estar desactualizado.
+---
+
+# Sync CLAUDE.md
+
+Verifica que CLAUDE.md refleje el estado real del proyecto y propone cambios concretos donde haya discrepancias. No modifica nada sin aprobación explícita.
+
+## Proceso
+
+1. Leer CLAUDE.md completo.
+
+2. Revisar cambios recientes para enfocar la auditoría:
+   ```bash
+   git log --oneline -20
+   ```
+
+3. Auditar cada sección de CLAUDE.md contra su fuente de verdad en el código:
+
+   | Sección | Fuente de verdad |
+   |---------|-----------------|
+   | Arquitectura / packages | Directorios en `packages/` |
+   | Eventos WebSocket | `packages/shared/src/events.ts` |
+   | Tipos compartidos | `packages/shared/src/types.ts` |
+   | Comandos | Scripts en `package.json` raíz y workspaces |
+   | Stack técnico | Dependencias en cada `package.json` |
+   | Componentes principales | `packages/client/src/components/` |
+   | Convenciones | Verificar que los paths y patrones mencionados existan |
+
+   Auditar **todas las secciones presentes** en CLAUDE.md, no solo las de la tabla. Para secciones sin fuente de verdad obvia en el código (ej: "Decisiones de diseño", "Filosofía del proyecto"), verificar que el contenido siga siendo coherente con el estado actual — si algo parece contradictorio o desactualizado, reportarlo y preguntar al usuario en vez de modificarlo directamente.
+
+4. Proponer cada cambio en formato diff:
+
+   ```diff
+   - línea desactualizada
+   + línea corregida
+   ```
+
+5. Aplicar solo después de confirmación. El usuario puede aprobar todo a la vez o sección por sección.
+
+Si no hay discrepancias: decirlo explícitamente — "CLAUDE.md está sincronizado con el código actual."
+
+## Reglas
+
+- No inventar información. Solo reportar lo verificable leyendo el código.
+- Mantener el estilo, idioma y formato del CLAUDE.md existente.
+- No agregar secciones nuevas sin consultar al usuario.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,29 @@
 ## 📋 Summary
+<!-- What does this PR do and why? 2–4 bullets. If the approach isn't obvious, explain the reasoning here — it saves back-and-forth during review. -->
+<!-- Closes #N -->
+
+-
+
 ## 🛠 Type of Change
-- [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
-- [ ] ✨ **New feature** (non-breaking change which adds functionality)
-- [ ] ♻️ **Refactor** (code change that neither fixes a bug nor adds a feature)
-- [ ] 🎨 **UI/UX** (visual changes in Shadcn/Tailwind)
-- [ ] ⚙️ **Config/Chore** (changes to package.json, CI/CD, tooling)
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature
+- [ ] ♻️ Refactor
+- [ ] 🎨 UI/UX
+- [ ] ⚙️ Config / Chore
+- [ ] 📄 Docs
 
 ## 🔍 How was it tested?
-1. Start the client (`pnpm dev` in client)
-2. Navigate to route `/workspace/...`
-3. Perform action X...
-4. Verify that component Y responds...
+<!-- Specific steps to verify this works. Tailor them to what actually changed: -->
+<!-- client/ → browser steps | server/ → requests or WebSocket events | shared/ → both packages compile -->
 
-## 📸 Visual Evidence (Optional)
+1.
+
+## 📸 Visual Evidence
+<!-- Screenshots or short video for UI changes. Remove this section if not applicable. -->
+
 | Before | After |
 |--------|-------|
-| [Image] | [Image] |
+|  |  |
 
-## 📝 TODO / Pending Technical Debt
-- [ ] Implement Zod validation in the backend for this endpoint.
-- [ ] Move `interface X` types to the shared library `@proxymity/shared`.
-- [ ] Add unit tests for the new utility function.
-- [ ] Resolve the `// TODO` comment left on line 45 of `App.tsx`.
-
-## ✅ Self-Review Checklist
-- [ ] My changes generate no new **ESLint** warnings or **TypeScript** errors.
-- [ ] I have run `pnpm knip` and verified that I am not introducing unused dependencies or dead code.
-- [ ] I have updated the documentation (if applicable).
+## 📝 Pending Technical Debt
+<!-- Intentional TODOs left for future iterations. Remove this section if there are none. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# Proxymity
+
+Herramienta colaborativa en tiempo real para depuración y testing de APIs HTTP. Funciona como un Postman compartido donde múltiples usuarios pueden editar y ejecutar requests dentro de una misma "sala" (room), viendo los cambios en vivo.
+
+## Arquitectura
+
+Monorepo TypeScript con pnpm workspaces:
+
+```
+packages/
+├── client/   → React 19 + Vite + Tailwind v4 + Zustand + Socket.IO Client
+├── server/   → Express 5 + Socket.IO + Axios (proxy de requests)
+└── shared/   → Tipos e interfaces compartidas (IRequestData, IResponseData, IRoomState, eventos)
+```
+
+## Modelo de colaboración
+
+- Los usuarios se conectan a una **room** identificada por `roomId`
+- El servidor mantiene el estado de cada room en memoria (`Map<RoomID, RoomState>`)
+- Cualquier cambio (método, URL, headers, params, body) se emite por WebSocket y se broadcast al resto de la room
+- Las respuestas HTTP y el estado de loading se sincronizan entre todos los usuarios
+- Last-write-wins: no hay resolución de conflictos
+
+## Flujo de datos
+
+```
+Usuario edita → Zustand store local → Socket emit → Servidor actualiza estado →
+Broadcast a la room → Otros clientes reciben → Zustand update → Re-render
+```
+
+## Ejecución de requests (ProxyService)
+
+- El servidor actúa como proxy: recibe la solicitud del cliente vía WebSocket, ejecuta el HTTP request con Axios y devuelve la respuesta
+- Timeout: 10 segundos
+- Protección SSRF: bloquea URLs a localhost/127.0.0.1
+- Límites: 50 items en headers/params, 100KB en body
+
+## Eventos WebSocket
+
+**Cliente → Servidor:** `client:join_room`, `client:leave_room`, `client:update_method`, `client:update_url`, `client:update_headers`, `client:update_params`, `client:update_body`, `client:execute_request`
+
+**Servidor → Cliente:** `server:sync_state`, `server:user_count`, `server:broadcast_change`, `server:request_started`, `server:request_complete`, `server:error`
+
+Definidos en `packages/shared/src/events.ts`.
+
+## Comandos
+
+```bash
+pnpm install          # Instalar dependencias
+pnpm dev              # Levantar client y server en paralelo (concurrently)
+pnpm server           # Solo servidor (nodemon, puerto 3001)
+pnpm client           # Solo cliente (Vite, puerto 3000)
+pnpm --filter @proxymity/client lint   # ESLint del client
+pnpm knip             # Detectar código muerto y dependencias sin usar
+```
+
+## Stack técnico
+
+| Capa | Tecnologías |
+|------|-------------|
+| **Client** | React 19, Zustand, Socket.IO Client, Monaco Editor, Radix UI, Tailwind CSS v4, CVA, lucide-react, react-syntax-highlighter |
+| **Server** | Express 5, Socket.IO, Axios, dotenv, cors |
+| **Shared** | TypeScript puro (tipos + constantes de eventos) |
+| **Tooling** | Vite, TypeScript, ESLint, knip, pnpm, concurrently, nodemon |
+
+## Componentes principales del client
+
+- **WorkspaceHeader** — Header con nombre de room y contador de usuarios activos
+- **RequestControls** — Selector de método HTTP, input de URL, botón Send
+- **RequestEditor** — Tabs con Params (KeyValueTable), Headers (KeyValueTable) y Body (Monaco Editor)
+- **ResponseViewer** — Badge de status, tiempo, tamaño, JSON con syntax highlighting y botón copiar
+- **KeyValueTable** — Tabla reutilizable de key-value con checkbox de habilitado
+
+## Convenciones
+
+- Los tipos compartidos van en `packages/shared/src/types.ts`
+- Los eventos WebSocket se definen como constantes en `packages/shared/src/events.ts`
+- Estado del cliente centralizado en Zustand (`packages/client/src/store/useAppStore.ts`)
+- Componentes UI base usan Radix UI + Shadcn pattern en `packages/client/src/components/ui/`
+- El tema es dark por defecto


### PR DESCRIPTION
## 📋 Summary
- Add `CLAUDE.md` with full project documentation: architecture, conventions, commands, data flow, and component descriptions
- Create 5 Claude Code skills for team workflow: `code-health`, `design-advisor`, `create-issue`, `create-pr`, `sync-claude-md`
- Configure 6 plugins and permission restrictions (deny `.env`, `rm -rf`, force push) via `.claude/settings.json`
- Establish conventions for branch naming (`type/kebab-case`), single-line commits, and PR templates

## 🛠 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [x] ⚙️ Config / Chore
- [ ] 📄 Docs

## 🔍 How was it tested?

1. Verified each skill file has valid YAML frontmatter and markdown structure
2. Confirmed `settings.json` has correct plugin references and restricted paths
3. Validated `CLAUDE.md` content matches current codebase state (packages, commands, components)

## 📝 Pending Technical Debt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project documentation outlining architecture, collaboration features, and development conventions.
  * Updated pull request template with streamlined checklist and improved guidance for contributors.

* **Chores**
  * Added internal configuration and automation workflows to support development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->