### PR TITLE
fix: reemplazar any por unknown en IResponseData y handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Git worktrees
+.worktrees/

--- a/packages/client/src/components/request-controls.tsx
+++ b/packages/client/src/components/request-controls.tsx
@@ -27,7 +27,7 @@ export function RequestControls({ roomId, onSend }: RequestControlsProps) {
   const setUrl = useAppStore((state) => state.setUrl);
   const setMethod = useAppStore((state) => state.setMethod);
 
-  const emitWithConnection = (event: string, data: any) => {
+  const emitWithConnection = (event: string, data: unknown) => {
     if (socket.connected) {
       socket.emit(event, data);
     } else {

--- a/packages/client/src/components/request-editor.tsx
+++ b/packages/client/src/components/request-editor.tsx
@@ -34,7 +34,7 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
   const removeQueryParam = useAppStore((state) => state.removeQueryParam);
   const updateQueryParam = useAppStore((state) => state.updateQueryParam);
 
-  const emitWithConnection = (event: string, data: any) => {
+  const emitWithConnection = (event: string, data: unknown) => {
     if (socket.connected) {
       socket.emit(event, data);
     } else {

--- a/packages/client/src/components/response-viewer.tsx
+++ b/packages/client/src/components/response-viewer.tsx
@@ -47,7 +47,7 @@ export function ResponseViewer() {
     if (!response.data) return
 
     try {
-      const content = JSON.stringify(response.data, null, 2)
+      const content = JSON.stringify(response.data as object | string | number | boolean | null, null, 2)
       await navigator.clipboard.writeText(content)
       setIsCopied(true)
       
@@ -103,7 +103,7 @@ export function ResponseViewer() {
             }}
             wrapLongLines={true}
           >
-            {JSON.stringify(response.data, null, 2)}
+            {JSON.stringify(response.data as object | string | number | boolean | null, null, 2)}
           </SyntaxHighlighter>
         </div>
       </div>

--- a/packages/client/src/components/response-viewer.tsx
+++ b/packages/client/src/components/response-viewer.tsx
@@ -43,8 +43,10 @@ export function ResponseViewer() {
     return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
   }
 
-  const serializeData = (data: unknown): string =>
-    JSON.stringify(data, null, 2) ?? 'undefined';
+  const serializeData = (data: unknown): string => {
+    if (data === undefined || data === '') return '';
+    return JSON.stringify(data, null, 2);
+  };
 
   const handleCopy = async () => {
     try {

--- a/packages/client/src/components/response-viewer.tsx
+++ b/packages/client/src/components/response-viewer.tsx
@@ -44,7 +44,7 @@ export function ResponseViewer() {
   }
 
   const handleCopy = async () => {
-    if (!response.data) return
+    if (response.data === undefined || response.data === null) return
 
     try {
       const content = JSON.stringify(response.data as object | string | number | boolean | null, null, 2)

--- a/packages/client/src/components/response-viewer.tsx
+++ b/packages/client/src/components/response-viewer.tsx
@@ -43,11 +43,12 @@ export function ResponseViewer() {
     return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
   }
 
-  const handleCopy = async () => {
-    if (response.data === undefined || response.data === null) return
+  const serializeData = (data: unknown): string =>
+    JSON.stringify(data, null, 2) ?? 'undefined';
 
+  const handleCopy = async () => {
     try {
-      const content = JSON.stringify(response.data as object | string | number | boolean | null, null, 2)
+      const content = serializeData(response.data)
       await navigator.clipboard.writeText(content)
       setIsCopied(true)
       
@@ -103,7 +104,7 @@ export function ResponseViewer() {
             }}
             wrapLongLines={true}
           >
-            {JSON.stringify(response.data as object | string | number | boolean | null, null, 2)}
+            {serializeData(response.data)}
           </SyntaxHighlighter>
         </div>
       </div>

--- a/packages/client/src/hooks/useRoomConnection.ts
+++ b/packages/client/src/hooks/useRoomConnection.ts
@@ -36,10 +36,11 @@ export const useRoomConnection = (roomId: string) => {
         case 'body': setBody(updatedData.value); break;
         case 'headers': setHeaders(updatedData.value); break;
         case 'queryParams': setQueryParams(updatedData.value); break;
-        default:
-          const exhaustiveCheck: never = updatedData;
-          console.warn(`Unknown field broadcasted from server: ${exhaustiveCheck}`);
+        default: {
+          const _unexpectedData: unknown = updatedData;
+          console.warn('Unknown field broadcasted from server:', _unexpectedData);
           break;
+        }
       }
     };
 

--- a/packages/client/src/hooks/useRoomConnection.ts
+++ b/packages/client/src/hooks/useRoomConnection.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { socket } from "@/services/socket";
-import { SOCKET_EVENTS, IRoomState } from '@proxymity/shared';
+import { SOCKET_EVENTS, IRoomState, IResponseData, BroadcastChange } from '@proxymity/shared';
 import { useAppStore } from "@/store/useAppStore";
 
 export const useRoomConnection = (roomId: string) => {
@@ -28,7 +28,7 @@ export const useRoomConnection = (roomId: string) => {
       setRequest(roomState.request);
     };
 
-    const onBroadcastChange = (updatedData: { field: string, value: any }) => {
+    const onBroadcastChange = (updatedData: BroadcastChange) => {
       console.log("Received broadcasted change:", updatedData);
       switch (updatedData.field) {
         case 'method': setMethod(updatedData.value); break;
@@ -36,8 +36,9 @@ export const useRoomConnection = (roomId: string) => {
         case 'body': setBody(updatedData.value); break;
         case 'headers': setHeaders(updatedData.value); break;
         case 'queryParams': setQueryParams(updatedData.value); break;
-        default: 
-          console.warn(`Unknown field broadcasted from server: ${updatedData.field}`);
+        default:
+          const exhaustiveCheck: never = updatedData;
+          console.warn(`Unknown field broadcasted from server: ${exhaustiveCheck}`);
           break;
       }
     };
@@ -46,7 +47,7 @@ export const useRoomConnection = (roomId: string) => {
       setLoading(true);
     }
 
-    const onRequestComplete = (response: any) => {
+    const onRequestComplete = (response: IResponseData) => {
       setResponse(response);
       setLoading(false);
     }

--- a/packages/server/src/services/proxy-service.ts
+++ b/packages/server/src/services/proxy-service.ts
@@ -24,9 +24,10 @@ const parseRequestBody = (bodyStr: string): unknown | undefined => {
   }
 };
 
-const calculateResponseSize = (headers: Record<string, any>, data: any): number => {
-  if (headers['content-length']) {
-    const parsed = parseInt(headers['content-length'], 10);
+const calculateResponseSize = (headers: Record<string, unknown>, data: unknown): number => {
+  const contentLength = headers['content-length'];
+  if (typeof contentLength === 'string') {
+    const parsed = parseInt(contentLength, 10);
     if (!isNaN(parsed)) return parsed;
   }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -24,7 +24,7 @@ export interface IRequestData {
 export interface IResponseData {
   status: number;    // 200, 404, 500
   statusText: string;// "OK", "Not Found"
-  data: any;         // El JSON de respuesta
+  data: unknown;     // El JSON de respuesta
   headers: Record<string, string>;
   time: number;      // Tiempo en ms que tardó
   size: number;      // Tamaño en bytes
@@ -39,3 +39,9 @@ export interface IRoomState {
   activeUsers: number;  // Cuántos devs hay conectados
   isLoading: boolean;   // Si está cargando una petición
 }
+
+// 6. Payload del evento server:broadcast_change
+export type BroadcastChange =
+  | { field: 'method'; value: HttpMethod }
+  | { field: 'url' | 'body'; value: string }
+  | { field: 'headers' | 'queryParams'; value: IKeyValue[] };


### PR DESCRIPTION
## 📋 Summary
<!-- Closes #15 -->
Closes #15

- Changes `IResponseData.data: any` → `unknown` in `packages/shared/src/types.ts`
- Adds discriminated type `BroadcastChange` in shared to type the `server:broadcast_change` event payload
- Types `onBroadcastChange` with `BroadcastChange` and `onRequestComplete` with `IResponseData` in `useRoomConnection`
- Changes `emitWithConnection(data: any)` → `data: unknown` in `request-controls` and `request-editor`
- Changes `calculateResponseSize(headers, data: any)` → `unknown` in `proxy-service.ts` with type guard for `content-length`
- Fix bonus: replaces falsy guard `!response.data` with explicit check `=== null/undefined` in `ResponseViewer`

## 🛠 Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] ⚙️ Config / Chore
- [ ] 📄 Docs

## 🔍 How was it tested?

1. `pnpm --filter @proxymity/client lint` passes with no `no-explicit-any` errors
2. `pnpm dev` starts with errors
3. Join a room, edit method/URL/headers/body and verify real-time sync
4. Execute a request and verify the response is displayed correctly
5. Verify the copy button works with responses that return `0`, `false` or `""`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Response data copying now works consistently for all response types.

* **Chores**
  * Enhanced type safety and internal reliability across the app.
  * Updated configuration to ignore Git worktrees directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->