### PR TITLE
chore: add .worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
## 📋 Summary
- Adds `.worktrees/` to `.gitignore` so git worktree directories created under the project root are not tracked

## 🛠 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [x] ⚙️ Config / Chore
- [ ] 📄 Docs

## 🔍 How was it tested?
- [ ] Verify `.worktrees/` entries do not appear in `git status` after creating a worktree under the project root

