### PR TITLE
POC: handle server:error event and surface proxy errors in UI

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { AlertTriangle } from "lucide-react"
 import { WorkspaceHeader } from "@/components/workspace-header"
 import { RequestControls } from "@/components/request-controls"
 import { RequestEditor } from "@/components/request-editor"
@@ -8,9 +9,20 @@ import { useRoomConnection } from "@/hooks/useRoomConnection"
 
 function App() {
   const [roomId] = useState<string>("example-room-id");
-  
+
   const { sendRequest } = useRoomConnection(roomId);
   const activeUsers = useAppStore((state) => state.activeUsers);
+  const serverError = useAppStore((state) => state.serverError);
+
+  if (serverError?.code === 'room_error') {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center gap-4 bg-background">
+        <AlertTriangle className="h-10 w-10 text-red-500" />
+        <h2 className="text-base font-semibold">Could not join room</h2>
+        <p className="text-sm text-muted-foreground">{serverError.message}</p>
+      </div>
+    )
+  }
 
   return (
     <div className="flex h-screen flex-col bg-background">

--- a/packages/client/src/components/response-viewer.tsx
+++ b/packages/client/src/components/response-viewer.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Loader2, Copy, Check } from "lucide-react"
+import { Loader2, Copy, Check, AlertCircle } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
@@ -10,6 +10,7 @@ export function ResponseViewer() {
     const [isCopied, setIsCopied] = useState(false)
     const isLoading = useAppStore((state) => state.isLoading);
     const response = useAppStore((state) => state.response);
+    const serverError = useAppStore((state) => state.serverError);
   
     if (isLoading) {
     return (
@@ -17,6 +18,18 @@ export function ResponseViewer() {
         <div className="flex flex-col items-center gap-3">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
           <p className="text-sm text-muted-foreground">Sending request...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (serverError) {
+    return (
+      <div className="flex h-full items-center justify-center p-6">
+        <div className="flex max-w-md flex-col items-center gap-3 text-center">
+          <AlertCircle className="h-8 w-8 text-red-500" />
+          <p className="text-sm font-medium text-red-500">Request failed</p>
+          <p className="text-sm text-muted-foreground">{serverError.message}</p>
         </div>
       </div>
     )

--- a/packages/client/src/hooks/useRoomConnection.ts
+++ b/packages/client/src/hooks/useRoomConnection.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { socket } from "@/services/socket";
-import { SOCKET_EVENTS, IRoomState } from '@proxymity/shared';
+import { SOCKET_EVENTS, IRoomState, IServerError } from '@proxymity/shared';
 import { useAppStore } from "@/store/useAppStore";
 
 export const useRoomConnection = (roomId: string) => {
@@ -13,6 +13,7 @@ export const useRoomConnection = (roomId: string) => {
   const setActiveUsers = useAppStore((state) => state.setActiveUsers);
   const setHeaders = useAppStore((state) => state.setHeaders);
   const setQueryParams = useAppStore((state) => state.setQueryParams);
+  const setServerError = useAppStore((state) => state.setServerError);
 
   useEffect(() => {
     const onConnect = () => {
@@ -24,12 +25,10 @@ export const useRoomConnection = (roomId: string) => {
     };
 
     const onSyncState = (roomState: IRoomState) => {
-      console.log("Received state from server:", roomState);
       setRequest(roomState.request);
     };
 
     const onBroadcastChange = (updatedData: { field: string, value: any }) => {
-      console.log("Received broadcasted change:", updatedData);
       switch (updatedData.field) {
         case 'method': setMethod(updatedData.value); break;
         case 'url': setUrl(updatedData.value); break;
@@ -44,6 +43,7 @@ export const useRoomConnection = (roomId: string) => {
 
     const onRequestStarted = () => {
       setLoading(true);
+      setServerError(null);
     }
 
     const onRequestComplete = (response: any) => {
@@ -55,6 +55,11 @@ export const useRoomConnection = (roomId: string) => {
       setActiveUsers(count);
     }
 
+    const onServerError = (error: IServerError) => {
+      setLoading(false);
+      setServerError(error);
+    }
+
     socket.on('connect', onConnect);
     socket.on('disconnect', onDisconnect);
     socket.on(SOCKET_EVENTS.SERVER.SYNC_STATE, onSyncState);
@@ -62,6 +67,7 @@ export const useRoomConnection = (roomId: string) => {
     socket.on(SOCKET_EVENTS.SERVER.REQUEST_STARTED, onRequestStarted);
     socket.on(SOCKET_EVENTS.SERVER.REQUEST_COMPLETE, onRequestComplete);
     socket.on(SOCKET_EVENTS.SERVER.USER_COUNT, onUserCount);
+    socket.on(SOCKET_EVENTS.SERVER.ERROR, onServerError);
 
     if (socket.connected) {
       onConnect();
@@ -75,16 +81,14 @@ export const useRoomConnection = (roomId: string) => {
       socket.off(SOCKET_EVENTS.SERVER.REQUEST_STARTED, onRequestStarted);
       socket.off(SOCKET_EVENTS.SERVER.REQUEST_COMPLETE, onRequestComplete);
       socket.off(SOCKET_EVENTS.SERVER.USER_COUNT, onUserCount);
+      socket.off(SOCKET_EVENTS.SERVER.ERROR, onServerError);
       if (socket.connected) {
         socket.emit(SOCKET_EVENTS.CLIENT.LEAVE_ROOM, roomId);
       }
     };
-  }, [roomId, setRequest, setMethod, setUrl, setBody, setHeaders, setQueryParams, setResponse, setLoading, setActiveUsers]);
+  }, [roomId, setRequest, setMethod, setUrl, setBody, setHeaders, setQueryParams, setResponse, setLoading, setActiveUsers, setServerError]);
 
   const sendRequest = () => {
-    const currentRequest = useAppStore.getState().request;
-    console.log("Sending request:", currentRequest);
-    console.log(roomId);
     socket.emit(SOCKET_EVENTS.CLIENT.EXECUTE_REQUEST, { roomId });
   };
 

--- a/packages/client/src/store/useAppStore.ts
+++ b/packages/client/src/store/useAppStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { nanoid } from "nanoid";
 
-import { IRequestData, IResponseData, HttpMethod, IKeyValue } from "@proxymity/shared";
+import { IRequestData, IResponseData, IServerError, HttpMethod, IKeyValue } from "@proxymity/shared";
 
 interface AppState {
   // State
@@ -9,6 +9,7 @@ interface AppState {
   response: IResponseData | null;
   isLoading: boolean;
   activeUsers: number;
+  serverError: IServerError | null;
 
   // Basic Actions
   setMethod: (method: HttpMethod) => void;
@@ -16,6 +17,7 @@ interface AppState {
   setBody: (body: string) => void;
   setResponse: (response: IResponseData | null) => void;
   setLoading: (isLoading: boolean) => void;
+  setServerError: (serverError: IServerError | null) => void;
   setRequest: (newRequest: IRequestData) => void;
   setActiveUsers: (count: number) => void;
   setHeaders: (headers: IKeyValue[]) => void;
@@ -44,6 +46,7 @@ export const useAppStore = create<AppState>()((set) => ({
   response: null,
   isLoading: false,
   activeUsers: 0,
+  serverError: null,
 
   setMethod: (method) =>
     set((state) => ({ request: { ...state.request, method } })),
@@ -56,6 +59,7 @@ export const useAppStore = create<AppState>()((set) => ({
 
   setResponse: (response) => set({ response }),
   setLoading: (isLoading) => set({ isLoading }),
+  setServerError: (serverError) => set({ serverError }),
   setRequest: (newRequest) => set({ request: newRequest }),
   setActiveUsers: (count) => set({ activeUsers: count }),
 

--- a/packages/server/src/handlers/request-handler.ts
+++ b/packages/server/src/handlers/request-handler.ts
@@ -29,8 +29,10 @@ const handleExecuteRequest = async (
     console.error(`[CRITICAL] Error executing request for room ${roomId}:`, criticalError);
     stateStore.setLoading(roomId, false);
     
-    io.to(roomId).emit(SOCKET_EVENTS.SERVER.ERROR, { 
-      message: 'Internal Proxy Error. Please try again.' 
+    const message = criticalError instanceof Error ? criticalError.message : 'Internal Proxy Error';
+    io.to(roomId).emit(SOCKET_EVENTS.SERVER.ERROR, {
+      message,
+      code: 'proxy_error'
     });
   }
 };

--- a/packages/server/src/handlers/room-handler.ts
+++ b/packages/server/src/handlers/room-handler.ts
@@ -104,7 +104,7 @@ export const registerRoomHandlers = (io: Server, socket: Socket) => {
   socket.on(SOCKET_EVENTS.CLIENT.JOIN_ROOM, (roomId: string) => {
     if (!roomId || typeof roomId !== 'string' || roomId.trim() === '') {
       console.warn(`[RoomHandler] Invalid roomId received from ${socket.id}`);
-      socket.emit(SOCKET_EVENTS.SERVER.ERROR, { message: "Invalid Room ID" });
+      socket.emit(SOCKET_EVENTS.SERVER.ERROR, { message: "Invalid Room ID", code: 'room_error' });
       return;
     }
     handleJoinRoom(io, socket, roomId);

--- a/packages/server/src/services/proxy-service.ts
+++ b/packages/server/src/services/proxy-service.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { IRequestData, IResponseData, IKeyValue } from '@proxymity/shared';
 
 /**
@@ -58,30 +58,12 @@ const createSuccessResponse = (
 });
 
 
-const createErrorResponse = (
-  error: unknown, 
-  durationMs: number
-): IResponseData => {
-  const isAxiosError = error instanceof AxiosError;
-  
-  return {
-    status: isAxiosError && error.response ? error.response.status : 0,
-    statusText: isAxiosError ? error.message : 'Unknown Internal Error',
-    data: isAxiosError && error.response ? error.response.data : null,
-    headers: {},
-    time: durationMs,
-    size: 0,
-    timestamp: Date.now(),
-  };
-};
-
-
 export const executeRequest = async (requestData: IRequestData): Promise<IResponseData> => {
   const startTime = Date.now();
 
   // Basic security check to prevent SSRF to localhost
   if (requestData.url.includes('localhost') || requestData.url.includes('127.0.0.1')) {
-     return createErrorResponse(new Error('Access to local resources is forbidden'), 0);
+    throw new Error('Access to local resources is forbidden');
   }
 
   const config: AxiosRequestConfig = {
@@ -91,13 +73,9 @@ export const executeRequest = async (requestData: IRequestData): Promise<IRespon
     params: mapHeadersToRecord(requestData.queryParams),
     data: parseRequestBody(requestData.body),
     validateStatus: () => true,
-    timeout: 10000, 
+    timeout: 10000,
   };
 
-  try {
-    const axiosResponse = await axios(config);
-    return createSuccessResponse(axiosResponse, Date.now() - startTime);
-  } catch (error) {
-    return createErrorResponse(error, Date.now() - startTime);
-  }
+  const axiosResponse = await axios(config);
+  return createSuccessResponse(axiosResponse, Date.now() - startTime);
 };

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -20,6 +20,6 @@ export const SOCKET_EVENTS = {
     BROADCAST_CHANGE: 'server:broadcast_change', 
     REQUEST_STARTED: 'server:request_started',   // "Loading..."
     REQUEST_COMPLETE: 'server:request_complete', // Payload: IResponseData
-    ERROR: 'server:error'                        // Payload: { message: string }
+    ERROR: 'server:error'                        // Payload: IServerError
   }
 } as const;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -31,7 +31,15 @@ export interface IResponseData {
   timestamp: number; // Cuándo ocurrió
 }
 
-// 5. El Estado Completo de la Sala
+// 5. Error del servidor
+export type ServerErrorCode = 'proxy_error' | 'room_error';
+
+export interface IServerError {
+  message: string;
+  code: ServerErrorCode;
+}
+
+// 6. El Estado Completo de la Sala
 export interface IRoomState {
   id: string;           // ID de la sala (ej: "room-abc")
   request: IRequestData;


### PR DESCRIPTION
## Summary
- Adds `server:error` listener in `useRoomConnection` to capture proxy-level errors from the server
- Surfaces error state in `App.tsx` with a dedicated error screen when the room connection fails
- Updates `ResponseViewer` to display error messages inline when a request fails
- Adds `proxyError` field to the app store and `IResponseData` type in shared types
- Refactors `proxy-service.ts` to emit structured errors via `server:error` instead of swallowing them

## Test Plan
- [ ] Trigger a request to an invalid/blocked URL (e.g. localhost) and verify the error message appears in the response viewer
- [ ] Disconnect the server mid-session and verify the error screen is shown in the client
- [ ] Verify successful requests still display normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server error handling with user-friendly error messages displayed throughout the application.
  * Implemented error differentiation for room connection failures and internal errors with specific error codes.

* **Bug Fixes**
  * Error messages now include detailed information from the server instead of generic fallback responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->