### PR TITLE
POC: add Minerale design system — fonts, color palette, and editor theme

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>client</title>
+    <title>Proxymity</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=JetBrains+Mono:wght@300;400;500&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/client/src/components/request-editor.tsx
+++ b/packages/client/src/components/request-editor.tsx
@@ -11,25 +11,38 @@ interface RequestEditorProps {
 
 export function RequestEditor({ roomId }: RequestEditorProps) {
   const handleEditorWillMount: BeforeMount = (monaco) => {
-    monaco.editor.defineTheme('proxymity-dark', {
+    monaco.editor.defineTheme('minerale-dark', {
       base: 'vs-dark',
       inherit: true,
-      rules: [],
+      rules: [
+        { token: 'string.key.json',   foreground: '5A8FC0' },
+        { token: 'string.value.json', foreground: 'A8C8A0' },
+        { token: 'number',            foreground: '8C7BC4' },
+        { token: 'keyword.json',      foreground: '4A9E6E' },
+        { token: 'string',            foreground: 'A8C8A0' },
+      ],
       colors: {
-        'editor.background': '#00000000', // Transparent background
-      }
+        'editor.background':              '#141618',
+        'editor.foreground':              '#E8EDF0',
+        'editorLineNumber.foreground':    '#404950',
+        'editor.selectionBackground':     '#25293080',
+        'editor.lineHighlightBackground': '#00000000',
+        'editorCursor.foreground':        '#3D8F82',
+        'editorIndentGuide.background1':  '#252930',
+        'editorBracketMatch.background':  'rgba(61,143,130,0.15)',
+        'editorBracketMatch.border':      'rgba(61,143,130,0.4)',
+      },
     });
   }
 
   const body = useAppStore((state) => state.request.body);
   const headers = useAppStore((state) => state.request.headers);
   const queryParams = useAppStore((state) => state.request.queryParams);
-  
+
   const setBody = useAppStore((state) => state.setBody);
   const addHeader = useAppStore((state) => state.addHeader);
   const removeHeader = useAppStore((state) => state.removeHeader);
   const updateHeader = useAppStore((state) => state.updateHeader);
-
   const addQueryParam = useAppStore((state) => state.addQueryParam);
   const removeQueryParam = useAppStore((state) => state.removeQueryParam);
   const updateQueryParam = useAppStore((state) => state.updateQueryParam);
@@ -38,9 +51,7 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
     if (socket.connected) {
       socket.emit(event, data);
     } else {
-      socket.once('connect', () => {
-        socket.emit(event, data);
-      });
+      socket.once('connect', () => socket.emit(event, data));
     }
   }
 
@@ -51,7 +62,7 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
   }
 
   const handleHeadersChange = (action: () => void) => {
-    try{ 
+    try {
       action();
       const updatedHeaders = useAppStore.getState().request.headers;
       emitWithConnection(SOCKET_EVENTS.CLIENT.UPDATE_HEADERS, { roomId, headers: updatedHeaders });
@@ -72,8 +83,8 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <Tabs defaultValue="params" className="flex flex-1 flex-col">
-        <TabsList className="w-full justify-start rounded-none border-b border-border bg-transparent px-6">
+      <Tabs defaultValue="params" className="flex flex-1 flex-col overflow-hidden">
+        <TabsList>
           <TabsTrigger value="params">Params</TabsTrigger>
           <TabsTrigger value="headers">Headers</TabsTrigger>
           <TabsTrigger value="body">Body</TabsTrigger>
@@ -99,46 +110,41 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
           />
         </TabsContent>
 
-        <TabsContent value="body" className="flex-1 overflow-auto p-6 mt-0">
-          <div className="flex h-full flex-col gap-2">
-            
-            <div className="relative flex-1 rounded-md border border-input bg-transparent shadow-sm focus-within:ring-1 focus-within:ring-ring transition-all overflow-hidden">
-              <Editor
-                height="100%"
-                defaultLanguage="json"
-                defaultValue={body}
-                value={body}
-                onChange={handleBodyChange}
-                theme="proxymity-dark"
-                beforeMount={handleEditorWillMount}
-                options={{
-                  minimap: { enabled: false },
-                  fontSize: 14,
-                  lineNumbers: "off",
-                  scrollBeyondLastLine: false,
-                  automaticLayout: true,
-                  tabSize: 2,
-                  formatOnPaste: true,
-                  formatOnType: true,
-                  fontFamily: 'var(--font-mono)',
-                  renderLineHighlight: "none",
-                  scrollbar: {
-                    vertical: "auto",
-                    horizontal: "auto",
-                    verticalScrollbarSize: 10,
-                  },
-                  overviewRulerLanes: 0,
-                  hideCursorInOverviewRuler: true,
-                }}
-              />
-            </div>
-            
-            <p className="text-xs text-muted-foreground">
-              Supports JSON format with syntax highlighting.
-            </p>
+        <TabsContent value="body" className="flex-1 overflow-hidden p-4 mt-0">
+          <div className="h-full rounded-sm overflow-hidden border border-border/60">
+            <Editor
+              height="100%"
+              defaultLanguage="json"
+              defaultValue={body}
+              value={body}
+              onChange={handleBodyChange}
+              theme="minerale-dark"
+              beforeMount={handleEditorWillMount}
+              options={{
+                minimap: { enabled: false },
+                fontSize: 13,
+                lineNumbers: "off",
+                scrollBeyondLastLine: false,
+                automaticLayout: true,
+                tabSize: 2,
+                formatOnPaste: true,
+                formatOnType: true,
+                fontFamily: '"JetBrains Mono", monospace',
+                fontLigatures: true,
+                renderLineHighlight: "none",
+                padding: { top: 12, bottom: 12 },
+                scrollbar: {
+                  vertical: "auto",
+                  horizontal: "auto",
+                  verticalScrollbarSize: 5,
+                },
+                overviewRulerLanes: 0,
+                hideCursorInOverviewRuler: true,
+              }}
+            />
           </div>
         </TabsContent>
       </Tabs>
     </div>
-  )
+  );
 }

--- a/packages/client/src/globals.css
+++ b/packages/client/src/globals.css
@@ -1,38 +1,36 @@
-@import url('https://fonts.googleapis.com/css2?family=BBH+Bartle&family=Geist:wght@100..900&display=swap');
 @import "tailwindcss";
 
-
 @theme {
-  --font-sans: "Geist", sans-serif;
-  --font-mono: "Geist Mono", monospace;
+  --font-sans: "IBM Plex Sans", sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
+  --font-display: "DM Serif Display", serif;
 
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
-
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
-
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
-  
   --color-popover: var(--popover);
   --color-popover-foreground: var(--popover-foreground);
-
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
-
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
-
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
-
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+
+  /* Minerale palette */
+  --color-min-teal: #3D8F82;
+  --color-min-success: #4A9E6E;
+  --color-min-error:   #B06060;
+  --color-min-info:    #5A8FC0;
+  --color-min-gold:    #B08840;
 
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
@@ -40,75 +38,137 @@
 }
 
 :root {
-  --background: oklch(0.985 0 0);
-  --foreground: oklch(0.145 0 0);
+  color-scheme: dark;
 
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
+  --background: #0D0F10;
+  --foreground: #E8EDF0;
 
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  --card: #141618;
+  --card-foreground: #E8EDF0;
 
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
+  --popover: #1A1D20;
+  --popover-foreground: #E8EDF0;
 
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --primary: #3D8F82;
+  --primary-foreground: #0D0F10;
 
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.985 0 0);
+  --secondary: #1A1D20;
+  --secondary-foreground: #E8EDF0;
 
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.205 0 0);
+  --muted: #181B1E;
+  --muted-foreground: #6B7880;
 
-  --radius: 0.5rem;
+  --accent: #252930;
+  --accent-foreground: #E8EDF0;
+
+  --destructive: #B06060;
+  --destructive-foreground: #E8EDF0;
+
+  --border: #252930;
+  --input: #181B1E;
+  --ring: rgba(61, 143, 130, 0.38);
+
+  --radius: 0.375rem;
 }
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-
-    --card: oklch(0.17 0 0);
-    --card-foreground: oklch(0.985 0 0);
-
-    --popover: oklch(0.17 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-
-    --primary: oklch(0.985 0 0);
-    --primary-foreground: oklch(0.145 0 0);
-
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-
-    --destructive: oklch(0.396 0.141 25.723);
-    --destructive-foreground: oklch(0.985 0 0);
-
-    --border: oklch(0.269 0 0);
-    --input: oklch(0.269 0 0);
-    --ring: oklch(0.439 0 0);
-  }
-}
-
 
 @layer base {
   *, ::after, ::before {
     @apply border-border outline-ring/50;
   }
+
   body {
     @apply bg-background text-foreground;
+    font-family: "IBM Plex Sans", sans-serif;
+    position: relative;
+  }
+
+  /* Precision dot grid overlay */
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background-image: radial-gradient(circle, rgba(255, 255, 255, 0.055) 1px, transparent 1px);
+    background-size: 22px 22px;
+    pointer-events: none;
+    z-index: 9999;
   }
 }
+
+/* ─── Animations ─────────────────────────────────────── */
+
+@keyframes min-fade-up {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes min-teal-breath {
+  0%, 100% { opacity: 0.5; transform: scale(1); }
+  50%       { opacity: 0.95; transform: scale(1.2); }
+}
+
+@keyframes min-teal-scan {
+  from { transform: translateX(-100%); }
+  to   { transform: translateX(100%); }
+}
+
+.min-page-enter {
+  animation: min-fade-up 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.min-page-enter-2 {
+  animation: min-fade-up 0.4s cubic-bezier(0.16, 1, 0.3, 1) 0.06s both;
+}
+
+.min-response-enter {
+  animation: min-fade-up 0.3s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.min-teal-breath {
+  animation: min-teal-breath 3s ease-in-out infinite;
+}
+
+/* ─── Tab overrides ──────────────────────────────────── */
+
+[data-slot="tabs-list"] {
+  background: transparent !important;
+  height: auto !important;
+  border-radius: 0 !important;
+  gap: 0 !important;
+  padding: 0 1.5rem !important;
+  border-bottom: 1px solid var(--border);
+}
+
+[data-slot="tabs-trigger"] {
+  font-family: "IBM Plex Sans", sans-serif !important;
+  font-size: 0.8rem !important;
+  font-weight: 400 !important;
+  letter-spacing: 0.01em !important;
+  color: var(--muted-foreground) !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+  padding: 0.6rem 0.875rem !important;
+  border-bottom: 1.5px solid transparent;
+  margin-bottom: -1px;
+  box-shadow: none !important;
+  transition: color 0.12s ease, border-color 0.12s ease !important;
+}
+
+[data-slot="tabs-trigger"]:hover {
+  color: var(--foreground) !important;
+  background: transparent !important;
+}
+
+[data-slot="tabs-trigger"][data-state="active"] {
+  color: var(--foreground) !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  border-bottom-color: #3D8F82 !important;
+  font-weight: 500 !important;
+}
+
+/* ─── Scrollbar ──────────────────────────────────────── */
+
+::-webkit-scrollbar { width: 5px; height: 5px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: #252930; border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: #30353C; }


### PR DESCRIPTION
## Summary
- Renames page title to "Proxymity" and imports Google Fonts: IBM Plex Sans (body), JetBrains Mono (monospace), DM Serif Display (display headings)
- Introduces the Minerale color palette: teal (#3D8F82), success (#4A9E6E), error (#B06060), info (#5A8FC0), gold (#B08840)
- Replaces oklch color tokens with explicit hex values tuned for the dark theme
- Adds CSS animations (`min-fade-up`, `min-teal-breath`, `min-teal-scan`) and entry utility classes
- Adds tab and scrollbar style overrides via `[data-slot]` selectors
- Adds dot-grid background overlay via `body::before`
- Renames Monaco editor theme from `proxymity-dark` to `minerale-dark` with expanded token rules matching the palette
- Simplifies `TabsList` to rely on global CSS overrides (removes hardcoded Tailwind classes)

## Test Plan
- [ ] Verify fonts load correctly (IBM Plex Sans for UI, JetBrains Mono in editor/code areas)
- [ ] Confirm Monaco editor theme renders with Minerale colors for JSON tokens
- [ ] Check tab bar and scrollbar styling apply from globals.css
- [ ] Verify dot-grid background appears behind content