### PR TITLE
POC: apply Minerale UI to request, response, and workspace components

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -16,10 +16,20 @@ function App() {
 
   if (serverError?.code === 'room_error') {
     return (
-      <div className="flex h-screen flex-col items-center justify-center gap-4 bg-background">
-        <AlertTriangle className="h-10 w-10 text-red-500" />
-        <h2 className="text-base font-semibold">Could not join room</h2>
-        <p className="text-sm text-muted-foreground">{serverError.message}</p>
+      <div className="flex h-screen flex-col items-center justify-center gap-3 bg-background min-page-enter">
+        <AlertTriangle className="h-6 w-6" style={{ color: '#B08840', opacity: 0.75 }} />
+        <h2
+          className="text-lg tracking-wide text-foreground"
+          style={{ fontFamily: '"DM Serif Display", serif' }}
+        >
+          Could not join room
+        </h2>
+        <p
+          className="text-xs"
+          style={{ color: '#6B7880', fontFamily: '"JetBrains Mono", monospace' }}
+        >
+          {serverError.message}
+        </p>
       </div>
     )
   }

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { AlertTriangle } from "lucide-react"
 import { WorkspaceHeader } from "@/components/workspace-header"
 import { RequestControls } from "@/components/request-controls"
 import { RequestEditor } from "@/components/request-editor"
@@ -8,9 +9,20 @@ import { useRoomConnection } from "@/hooks/useRoomConnection"
 
 function App() {
   const [roomId] = useState<string>("example-room-id");
-  
+
   const { sendRequest } = useRoomConnection(roomId);
   const activeUsers = useAppStore((state) => state.activeUsers);
+  const serverError = useAppStore((state) => state.serverError);
+
+  if (serverError?.code === 'room_error') {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center gap-4 bg-background">
+        <AlertTriangle className="h-10 w-10 text-red-500" />
+        <h2 className="text-base font-semibold">Could not join room</h2>
+        <p className="text-sm text-muted-foreground">{serverError.message}</p>
+      </div>
+    )
+  }
 
   return (
     <div className="flex h-screen flex-col bg-background">

--- a/packages/client/src/components/key-value-table.tsx
+++ b/packages/client/src/components/key-value-table.tsx
@@ -13,28 +13,51 @@ interface KeyValueTableProps {
 }
 
 export function KeyValueTable({ items, onAdd, onDelete, onUpdate, placeholder = "Key" }: KeyValueTableProps) {
-  
   return (
-    <div className="space-y-2">
-      <div className="grid grid-cols-[auto_1fr_1fr_auto] gap-2 text-xs font-medium text-muted-foreground px-2">
-        <div className="w-8"></div>
-        <div>KEY</div>
-        <div>VALUE</div>
-        <div className="w-8"></div>
+    <div className="space-y-1.5">
+      {/* Column labels */}
+      <div className="grid grid-cols-[auto_1fr_1fr_auto] gap-2 px-2 pb-1.5 border-b border-border/50">
+        <div className="w-7" />
+        <div
+          className="text-[0.6875rem] tracking-[0.1em] uppercase"
+          style={{ color: '#404950' }}
+        >
+          Key
+        </div>
+        <div
+          className="text-[0.6875rem] tracking-[0.1em] uppercase"
+          style={{ color: '#404950' }}
+        >
+          Value
+        </div>
+        <div className="w-7" />
       </div>
 
       {items.map((item) => (
-        <div key={item.id} className="grid grid-cols-[auto_1fr_1fr_auto] gap-2 items-center">
+        <div
+          key={item.id}
+          className="grid grid-cols-[auto_1fr_1fr_auto] gap-2 items-center px-1 rounded-sm"
+          style={{ opacity: item.isEnabled ? 1 : 0.38, transition: 'opacity 0.15s ease' }}
+        >
           <Checkbox
             checked={item.isEnabled}
             onCheckedChange={(checked) => onUpdate(item.id, "isEnabled", checked === true)}
+            className="w-4 h-4"
           />
           <Input
             type="text"
             placeholder={placeholder}
             value={item.key}
             onChange={(e) => onUpdate(item.id, "key", e.target.value)}
-            className="font-mono text-sm"
+            className="text-xs h-7.5 border-0 border-b rounded-none px-1 focus-visible:ring-0 focus-visible:border-b-[var(--color-min-teal)]"
+            style={{
+              backgroundColor: 'transparent',
+              borderBottomColor: '#252930',
+              borderBottomWidth: '1px',
+              color: '#5A8FC0',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.75rem',
+            }}
             disabled={!item.isEnabled}
           />
           <Input
@@ -42,19 +65,41 @@ export function KeyValueTable({ items, onAdd, onDelete, onUpdate, placeholder = 
             placeholder="Value"
             value={item.value}
             onChange={(e) => onUpdate(item.id, "value", e.target.value)}
-            className="font-mono text-sm"
+            className="text-xs h-7.5 border-0 border-b rounded-none px-1 focus-visible:ring-0"
+            style={{
+              backgroundColor: 'transparent',
+              borderBottomColor: '#252930',
+              borderBottomWidth: '1px',
+              color: '#E8EDF0',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.75rem',
+            }}
             disabled={!item.isEnabled}
           />
-          <Button variant="ghost" size="icon" onClick={() => onDelete(item.id)} className="h-8 w-8">
-            <Trash2 className="h-4 w-4 text-muted-foreground hover:text-destructive" />
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => onDelete(item.id)}
+            className="h-7 w-7 transition-colors hover:text-destructive"
+          >
+            <Trash2 className="h-3 w-3" style={{ color: '#404950' }} />
           </Button>
         </div>
       ))}
 
-      <Button variant="outline" size="sm" onClick={onAdd} className="w-full gap-2 mt-4 bg-transparent">
-        <Plus className="h-4 w-4" />
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onAdd}
+        className="w-full gap-2 mt-4 text-xs transition-colors border border-dashed"
+        style={{
+          color: '#3D8F82',
+          borderColor: 'rgba(61, 143, 130, 0.25)',
+        }}
+      >
+        <Plus className="h-3.5 w-3.5" />
         Add {placeholder}
       </Button>
     </div>
-  )
+  );
 }

--- a/packages/client/src/components/request-controls.tsx
+++ b/packages/client/src/components/request-controls.tsx
@@ -1,4 +1,4 @@
-import { Play, Loader2 } from "lucide-react"
+import { Loader2, Send } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -11,14 +11,13 @@ interface RequestControlsProps {
   onSend: () => void
 }
 
-const METHOD_COLORS: Record<HttpMethod, string> = {
-  GET: "text-blue-500",
-  POST: "text-emerald-500",
-  PUT: "text-amber-500",
-  DELETE: "text-red-500",
-  PATCH: "text-purple-500",
+const METHOD_STYLES: Record<HttpMethod, { color: string; bg: string; border: string }> = {
+  GET:    { color: '#5A8FC0', bg: 'rgba(90, 143, 192, 0.07)',  border: 'rgba(90, 143, 192, 0.22)'  },
+  POST:   { color: '#4A9E6E', bg: 'rgba(74, 158, 110, 0.07)',  border: 'rgba(74, 158, 110, 0.22)'  },
+  PUT:    { color: '#B08840', bg: 'rgba(176, 136, 64, 0.07)',   border: 'rgba(176, 136, 64, 0.22)'  },
+  DELETE: { color: '#B06060', bg: 'rgba(176, 96, 96, 0.07)',    border: 'rgba(176, 96, 96, 0.22)'   },
+  PATCH:  { color: '#8C7BC4', bg: 'rgba(140, 123, 196, 0.07)', border: 'rgba(140, 123, 196, 0.22)' },
 }
-
 
 export function RequestControls({ roomId, onSend }: RequestControlsProps) {
   const url = useAppStore((state) => state.request.url);
@@ -31,9 +30,7 @@ export function RequestControls({ roomId, onSend }: RequestControlsProps) {
     if (socket.connected) {
       socket.emit(event, data);
     } else {
-      socket.once('connect', () => {
-        socket.emit(event, data);
-      });
+      socket.once('connect', () => socket.emit(event, data));
     }
   }
 
@@ -48,27 +45,39 @@ export function RequestControls({ roomId, onSend }: RequestControlsProps) {
     emitWithConnection(SOCKET_EVENTS.CLIENT.UPDATE_URL, { roomId, url: newUrl });
   }
 
+  const ms = METHOD_STYLES[method];
+
   return (
-    <div className="flex items-center gap-3 border-b border-border bg-card/50 px-6 py-4">
-      <Select
-        value={method}
-        onValueChange={handleMethodChange}
-      >
-        <SelectTrigger className={`w-32 font-semibold ${METHOD_COLORS[method]}`}>
+    <div
+      className="min-page-enter-2 flex items-center gap-3 border-b border-border px-6 py-3"
+      style={{ backgroundColor: '#141618' }}
+    >
+      <Select value={method} onValueChange={handleMethodChange}>
+        <SelectTrigger
+          className="w-[100px] font-mono font-medium text-sm border transition-all"
+          style={{
+            color: ms.color,
+            backgroundColor: ms.bg,
+            borderColor: ms.border,
+            fontFamily: '"JetBrains Mono", monospace',
+          }}
+        >
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          {
-            Object.keys(METHOD_COLORS).map((method) => (
+          {(Object.keys(METHOD_STYLES) as HttpMethod[]).map((m) => {
+            const s = METHOD_STYLES[m];
+            return (
               <SelectItem
-                key={method}
-                value={method}
-                className={`font-semibold ${METHOD_COLORS[method as HttpMethod]}`}
+                key={m}
+                value={m}
+                className="font-mono font-medium text-sm"
+                style={{ color: s.color, fontFamily: '"JetBrains Mono", monospace' }}
               >
-                {method}
+                {m}
               </SelectItem>
-            ))
-          }
+            );
+          })}
         </SelectContent>
       </Select>
 
@@ -77,17 +86,31 @@ export function RequestControls({ roomId, onSend }: RequestControlsProps) {
         placeholder="https://api.example.com/endpoint"
         value={url}
         onChange={handleUrlChange}
-        className="flex-1 font-mono text-sm"
+        className="flex-1 text-sm"
+        style={{
+          backgroundColor: '#0D0F10',
+          borderColor: '#252930',
+          color: '#E8EDF0',
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.8125rem',
+        }}
       />
 
-      <Button onClick={onSend} disabled={isLoading} className="gap-2 min-w-28" size="default">
-        {isLoading ? (
-          <Loader2 className="h-4 w-4 animate-spin" /> // Loading spinner
-        ) : (
-          <Play className="h-4 w-4" /> // Play icon
-        )}
-        {isLoading ? "Sending..." : "Send"}
+      <Button
+        onClick={onSend}
+        disabled={isLoading}
+        className="gap-2 min-w-24 text-sm font-medium border-0 transition-all"
+        style={{
+          backgroundColor: isLoading ? 'rgba(61, 143, 130, 0.4)' : '#3D8F82',
+          color: '#0D0F10',
+        }}
+      >
+        {isLoading
+          ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          : <Send className="h-3.5 w-3.5" />
+        }
+        {isLoading ? "Sending…" : "Send"}
       </Button>
     </div>
-  )
+  );
 }

--- a/packages/client/src/components/response-viewer.tsx
+++ b/packages/client/src/components/response-viewer.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Loader2, Copy, Check } from "lucide-react"
+import { Loader2, Copy, Check, AlertCircle } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
@@ -10,6 +10,7 @@ export function ResponseViewer() {
     const [isCopied, setIsCopied] = useState(false)
     const isLoading = useAppStore((state) => state.isLoading);
     const response = useAppStore((state) => state.response);
+    const serverError = useAppStore((state) => state.serverError);
   
     if (isLoading) {
     return (
@@ -17,6 +18,18 @@ export function ResponseViewer() {
         <div className="flex flex-col items-center gap-3">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
           <p className="text-sm text-muted-foreground">Sending request...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (serverError) {
+    return (
+      <div className="flex h-full items-center justify-center p-6">
+        <div className="flex max-w-md flex-col items-center gap-3 text-center">
+          <AlertCircle className="h-8 w-8 text-red-500" />
+          <p className="text-sm font-medium text-red-500">Request failed</p>
+          <p className="text-sm text-muted-foreground">{serverError.message}</p>
         </div>
       </div>
     )

--- a/packages/client/src/components/response-viewer.tsx
+++ b/packages/client/src/components/response-viewer.tsx
@@ -1,69 +1,108 @@
 import { useState } from "react"
 import { Loader2, Copy, Check, AlertCircle } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import { useAppStore } from "@/store/useAppStore"
 
+// Minerale syntax theme — cool tones
+const mineraleTheme: Record<string, React.CSSProperties> = {
+  'code[class*="language-"]': {
+    color: '#E8EDF0',
+    fontFamily: '"JetBrains Mono", monospace',
+    fontSize: '0.8125rem',
+    lineHeight: '1.65',
+  },
+  'token.property': { color: '#5A8FC0' },
+  'token.string':   { color: '#A8C8A0' },
+  'token.number':   { color: '#8C7BC4' },
+  'token.boolean':  { color: '#4A9E6E' },
+  'token.null':     { color: '#6B7880' },
+  'token.punctuation': { color: '#6B7880' },
+  'token.operator': { color: '#6B7880' },
+}
+
+const STATUS_META: Record<string, { color: string; bg: string; border: string; label: string }> = {
+  '2': { color: '#4A9E6E', bg: 'rgba(74, 158, 110, 0.08)',  border: 'rgba(74, 158, 110, 0.2)',  label: 'OK' },
+  '3': { color: '#5A8FC0', bg: 'rgba(90, 143, 192, 0.08)',  border: 'rgba(90, 143, 192, 0.2)',  label: 'REDIRECT' },
+  '4': { color: '#B08840', bg: 'rgba(176, 136, 64, 0.08)',  border: 'rgba(176, 136, 64, 0.2)',  label: 'CLIENT ERR' },
+  '5': { color: '#B06060', bg: 'rgba(176, 96, 96, 0.08)',   border: 'rgba(176, 96, 96, 0.2)',   label: 'SERVER ERR' },
+}
+
+function getStatusMeta(status: number) {
+  return STATUS_META[String(Math.floor(status / 100))] ?? STATUS_META['5'];
+}
+
+const formatBytes = (bytes: number) => {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
 export function ResponseViewer() {
-    const [isCopied, setIsCopied] = useState(false)
-    const isLoading = useAppStore((state) => state.isLoading);
-    const response = useAppStore((state) => state.response);
-    const serverError = useAppStore((state) => state.serverError);
-  
-    if (isLoading) {
+  const [isCopied, setIsCopied] = useState(false)
+  const isLoading = useAppStore((state) => state.isLoading);
+  const response = useAppStore((state) => state.response);
+  const serverError = useAppStore((state) => state.serverError);
+
+  if (isLoading) {
     return (
       <div className="flex h-full items-center justify-center">
-        <div className="flex flex-col items-center gap-3">
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-          <p className="text-sm text-muted-foreground">Sending request...</p>
+        <div className="flex flex-col items-center gap-4">
+          <Loader2
+            className="h-6 w-6 animate-spin"
+            style={{ color: '#3D8F82', opacity: 0.75 }}
+          />
+          <p
+            className="text-[0.6875rem] tracking-[0.08em] uppercase"
+            style={{ color: '#404950' }}
+          >
+            Sending request
+          </p>
         </div>
       </div>
-    )
+    );
   }
 
   if (serverError) {
     return (
-      <div className="flex h-full items-center justify-center p-6">
-        <div className="flex max-w-md flex-col items-center gap-3 text-center">
-          <AlertCircle className="h-8 w-8 text-red-500" />
-          <p className="text-sm font-medium text-red-500">Request failed</p>
-          <p className="text-sm text-muted-foreground">{serverError.message}</p>
+      <div className="flex h-full items-center justify-center p-8">
+        <div className="flex max-w-sm flex-col items-center gap-3 text-center min-response-enter">
+          <AlertCircle className="h-6 w-6" style={{ color: '#B06060', opacity: 0.75 }} />
+          <p className="text-sm font-medium" style={{ color: '#B06060' }}>Request failed</p>
+          <p
+            className="text-xs leading-relaxed"
+            style={{ color: '#6B7880', fontFamily: '"JetBrains Mono", monospace' }}
+          >
+            {serverError.message}
+          </p>
         </div>
       </div>
-    )
+    );
   }
 
   if (!response) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-sm text-muted-foreground">No response yet. Send a request to see the results.</p>
+        <div className="flex flex-col items-center gap-2 select-none">
+          <p
+            className="text-[0.6875rem] tracking-[0.1em] uppercase"
+            style={{ color: '#303840' }}
+          >
+            Awaiting response
+          </p>
+        </div>
       </div>
-    )
+    );
   }
 
-  const getStatusColor = (status: number) => {
-    if (status >= 200 && status < 300) return "text-emerald-500 bg-emerald-500/10"
-    if (status >= 300 && status < 400) return "text-blue-500 bg-blue-500/10"
-    if (status >= 400 && status < 500) return "text-amber-500 bg-amber-500/10"
-    return "text-red-500 bg-red-500/10"
-  }
-
-  const formatBytes = (bytes: number) => {
-    if (bytes < 1024) return `${bytes} B`
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`
-    return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
-  }
+  const meta = getStatusMeta(response.status);
+  const isSuccess = response.status >= 200 && response.status < 300;
 
   const handleCopy = async () => {
     if (!response.data) return
-
     try {
-      const content = JSON.stringify(response.data, null, 2)
-      await navigator.clipboard.writeText(content)
+      await navigator.clipboard.writeText(JSON.stringify(response.data, null, 2))
       setIsCopied(true)
-      
       setTimeout(() => setIsCopied(false), 2000)
     } catch (err) {
       console.error("Failed to copy:", err)
@@ -71,48 +110,100 @@ export function ResponseViewer() {
   }
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex items-center gap-4 border-b border-border bg-card/50 px-6 py-4">
-        <Badge className={`font-semibold ${getStatusColor(response.status)}`}>
-          {response.status} {response.statusText}
-        </Badge>
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <span>Time:</span>
-          <span className="font-mono font-medium text-foreground">{response.time}ms</span>
+    <div
+      className="flex h-full flex-col transition-all duration-700"
+      style={isSuccess ? {
+        boxShadow: 'inset 0 0 80px 0 rgba(61, 143, 130, 0.05)',
+      } : undefined}
+    >
+      {/* Status bar */}
+      <div
+        key={response.timestamp}
+        className="min-response-enter flex items-center gap-4 border-b border-border px-6 py-3.5"
+        style={{ backgroundColor: '#141618' }}
+      >
+        {/* Left accent line */}
+        <div
+          className="w-0.5 h-8 rounded-full self-center flex-shrink-0"
+          style={{ backgroundColor: meta.color, opacity: 0.6 }}
+        />
+
+        {/* Status code */}
+        <div>
+          <div className="flex items-baseline gap-2">
+            <span
+              className="font-mono text-xl font-semibold tabular-nums"
+              style={{ color: meta.color, fontFamily: '"JetBrains Mono", monospace' }}
+            >
+              {response.status}
+            </span>
+            <span
+              className="text-xs font-mono tracking-wide"
+              style={{ color: meta.color, opacity: 0.6 }}
+            >
+              {response.statusText}
+            </span>
+          </div>
         </div>
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <span>Size:</span>
-          <span className="font-mono font-medium text-foreground">{formatBytes(response.size)}</span>
+
+        {/* Divider */}
+        <div className="w-px h-5 bg-border self-center flex-shrink-0" />
+
+        {/* Metadata */}
+        <div className="flex items-center gap-4 text-xs">
+          <span>
+            <span style={{ color: '#404950' }}>time </span>
+            <span
+              className="font-mono"
+              style={{ color: '#E8EDF0', fontFamily: '"JetBrains Mono", monospace' }}
+            >
+              {response.time}ms
+            </span>
+          </span>
+          <span>
+            <span style={{ color: '#404950' }}>size </span>
+            <span
+              className="font-mono"
+              style={{ color: '#E8EDF0', fontFamily: '"JetBrains Mono", monospace' }}
+            >
+              {formatBytes(response.size)}
+            </span>
+          </span>
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto p-6">
-        <div className="group relative rounded-lg bg-muted/20 overflow-hidden border border-border/50">
-          
+      {/* Response body */}
+      <div className="flex-1 overflow-auto p-5">
+        <div
+          key={`body-${response.timestamp}`}
+          className="min-response-enter group relative rounded-sm border overflow-hidden"
+          style={{ borderColor: '#252930', backgroundColor: '#141618' }}
+        >
           <Button
             size="icon"
             variant="ghost"
-            className="absolute right-2 top-2 h-8 w-8 bg-background/50 text-muted-foreground opacity-0 backdrop-blur-sm transition-opacity hover:bg-background hover:text-foreground group-hover:opacity-100"
+            className="absolute right-2 top-2 h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100"
+            style={{ backgroundColor: 'rgba(13, 15, 16, 0.85)' }}
             onClick={handleCopy}
-            title="Copy to clipboard"
+            title="Copy"
           >
-            {isCopied ? (
-              <Check className="h-4 w-4 text-emerald-500" />
-            ) : (
-              <Copy className="h-4 w-4" />
-            )}
+            {isCopied
+              ? <Check className="h-3.5 w-3.5" style={{ color: '#4A9E6E' }} />
+              : <Copy className="h-3.5 w-3.5" style={{ color: '#6B7880' }} />
+            }
           </Button>
-        
+
           <SyntaxHighlighter
             language="json"
-            style={vscDarkPlus}
+            useInlineStyles={false}
+            style={mineraleTheme}
             customStyle={{
               margin: 0,
               padding: '1rem',
               background: 'transparent',
-              fontSize: '0.875rem',
-              lineHeight: '1.5',
-              fontFamily: 'var(--font-mono)',
+              fontSize: '0.8125rem',
+              lineHeight: '1.65',
+              fontFamily: '"JetBrains Mono", monospace',
             }}
             wrapLongLines={true}
           >
@@ -121,5 +212,5 @@ export function ResponseViewer() {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/packages/client/src/components/workspace-header.tsx
+++ b/packages/client/src/components/workspace-header.tsx
@@ -1,28 +1,93 @@
-import { Users } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
-
 interface WorkspaceHeaderProps {
-	roomId: string;
-	activeUsers: number;
+  roomId: string;
+  activeUsers: number;
 }
 
-export function WorkspaceHeader({ roomId, activeUsers }: WorkspaceHeaderProps) {
-	return (
-		<header className="flex items-center justify-between border-b border-border bg-card px-6 py-3">
-			<div className="flex items-center gap-4">
-				<h1 className="text-xl font-semibold text-foreground">Proxymity</h1>
-				<Badge variant="secondary" className="font-mono text-xs rounded-md">
-				{roomId}
-				</Badge>
-			</div>
+const AVATAR_COLORS = [
+  { bg: 'rgba(61, 143, 130, 0.12)',  border: 'rgba(61, 143, 130, 0.28)',  text: '#3D8F82' },
+  { bg: 'rgba(74, 158, 110, 0.12)',  border: 'rgba(74, 158, 110, 0.28)',  text: '#4A9E6E' },
+  { bg: 'rgba(90, 143, 192, 0.12)',  border: 'rgba(90, 143, 192, 0.28)',  text: '#5A8FC0' },
+  { bg: 'rgba(140, 123, 196, 0.12)', border: 'rgba(140, 123, 196, 0.28)', text: '#8C7BC4' },
+];
 
-			<div className="flex items-center gap-2">
-				<div className="flex items-center gap-2 rounded-md bg-emerald-500/10 px-3 py-1.5">
-				<div className="h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
-				<Users className="h-4 w-4 text-emerald-500" />
-				<span className="text-sm font-medium text-emerald-500">{activeUsers}</span>
-				</div>
-			</div>
-		</header>
-	)
+const AVATAR_INITIALS = ['W', 'J', 'A', 'M'];
+
+export function WorkspaceHeader({ roomId, activeUsers }: WorkspaceHeaderProps) {
+  const visible = Math.min(activeUsers, 4);
+  const extra = Math.max(0, activeUsers - 4);
+
+  return (
+    <header className="min-page-enter flex items-center justify-between border-b border-border px-6 py-4"
+      style={{ backgroundColor: '#141618' }}
+    >
+      {/* Brand — upright serif, more architectural than the italic POC 1 */}
+      <div className="flex items-center gap-3">
+        <div
+          className="w-1.5 h-1.5 rounded-full min-teal-breath"
+          style={{ backgroundColor: '#3D8F82' }}
+        />
+        <h1
+          className="text-[1.1875rem] tracking-wide text-foreground select-none"
+          style={{ fontFamily: '"DM Serif Display", serif' }}
+        >
+          Proxymity
+        </h1>
+        {/* Slash separator */}
+        <span className="text-border text-base select-none" style={{ color: '#252930' }}>/</span>
+        <span
+          className="font-mono text-xs tracking-wider"
+          style={{ color: '#6B7880', fontFamily: '"JetBrains Mono", monospace' }}
+        >
+          {roomId}
+        </span>
+      </div>
+
+      {/* Users */}
+      {activeUsers > 0 && (
+        <div className="flex items-center gap-3">
+          <span
+            className="text-[0.6875rem] tracking-[0.12em] uppercase select-none"
+            style={{ color: '#404950' }}
+          >
+            {activeUsers} online
+          </span>
+          <div className="flex items-center">
+            {Array.from({ length: visible }).map((_, i) => {
+              const c = AVATAR_COLORS[i % AVATAR_COLORS.length];
+              return (
+                <div
+                  key={i}
+                  className="relative w-6 h-6 rounded-full flex items-center justify-center text-[0.625rem] font-semibold border"
+                  style={{
+                    backgroundColor: c.bg,
+                    borderColor: c.border,
+                    color: c.text,
+                    marginLeft: i === 0 ? 0 : -6,
+                    zIndex: visible - i,
+                    fontFamily: '"IBM Plex Sans", sans-serif',
+                  }}
+                >
+                  {AVATAR_INITIALS[i % AVATAR_INITIALS.length]}
+                </div>
+              );
+            })}
+            {extra > 0 && (
+              <div
+                className="relative w-6 h-6 rounded-full flex items-center justify-center text-[0.625rem] border"
+                style={{
+                  marginLeft: -6,
+                  zIndex: 0,
+                  backgroundColor: 'rgba(37, 41, 48, 0.9)',
+                  borderColor: '#252930',
+                  color: '#6B7880',
+                }}
+              >
+                +{extra}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </header>
+  );
 }

--- a/packages/client/src/hooks/useRoomConnection.ts
+++ b/packages/client/src/hooks/useRoomConnection.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { socket } from "@/services/socket";
-import { SOCKET_EVENTS, IRoomState } from '@proxymity/shared';
+import { SOCKET_EVENTS, IRoomState, IServerError } from '@proxymity/shared';
 import { useAppStore } from "@/store/useAppStore";
 
 export const useRoomConnection = (roomId: string) => {
@@ -13,6 +13,7 @@ export const useRoomConnection = (roomId: string) => {
   const setActiveUsers = useAppStore((state) => state.setActiveUsers);
   const setHeaders = useAppStore((state) => state.setHeaders);
   const setQueryParams = useAppStore((state) => state.setQueryParams);
+  const setServerError = useAppStore((state) => state.setServerError);
 
   useEffect(() => {
     const onConnect = () => {
@@ -24,12 +25,10 @@ export const useRoomConnection = (roomId: string) => {
     };
 
     const onSyncState = (roomState: IRoomState) => {
-      console.log("Received state from server:", roomState);
       setRequest(roomState.request);
     };
 
     const onBroadcastChange = (updatedData: { field: string, value: any }) => {
-      console.log("Received broadcasted change:", updatedData);
       switch (updatedData.field) {
         case 'method': setMethod(updatedData.value); break;
         case 'url': setUrl(updatedData.value); break;
@@ -44,6 +43,7 @@ export const useRoomConnection = (roomId: string) => {
 
     const onRequestStarted = () => {
       setLoading(true);
+      setServerError(null);
     }
 
     const onRequestComplete = (response: any) => {
@@ -55,6 +55,11 @@ export const useRoomConnection = (roomId: string) => {
       setActiveUsers(count);
     }
 
+    const onServerError = (error: IServerError) => {
+      setLoading(false);
+      setServerError(error);
+    }
+
     socket.on('connect', onConnect);
     socket.on('disconnect', onDisconnect);
     socket.on(SOCKET_EVENTS.SERVER.SYNC_STATE, onSyncState);
@@ -62,6 +67,7 @@ export const useRoomConnection = (roomId: string) => {
     socket.on(SOCKET_EVENTS.SERVER.REQUEST_STARTED, onRequestStarted);
     socket.on(SOCKET_EVENTS.SERVER.REQUEST_COMPLETE, onRequestComplete);
     socket.on(SOCKET_EVENTS.SERVER.USER_COUNT, onUserCount);
+    socket.on(SOCKET_EVENTS.SERVER.ERROR, onServerError);
 
     if (socket.connected) {
       onConnect();
@@ -75,16 +81,14 @@ export const useRoomConnection = (roomId: string) => {
       socket.off(SOCKET_EVENTS.SERVER.REQUEST_STARTED, onRequestStarted);
       socket.off(SOCKET_EVENTS.SERVER.REQUEST_COMPLETE, onRequestComplete);
       socket.off(SOCKET_EVENTS.SERVER.USER_COUNT, onUserCount);
+      socket.off(SOCKET_EVENTS.SERVER.ERROR, onServerError);
       if (socket.connected) {
         socket.emit(SOCKET_EVENTS.CLIENT.LEAVE_ROOM, roomId);
       }
     };
-  }, [roomId, setRequest, setMethod, setUrl, setBody, setHeaders, setQueryParams, setResponse, setLoading, setActiveUsers]);
+  }, [roomId, setRequest, setMethod, setUrl, setBody, setHeaders, setQueryParams, setResponse, setLoading, setActiveUsers, setServerError]);
 
   const sendRequest = () => {
-    const currentRequest = useAppStore.getState().request;
-    console.log("Sending request:", currentRequest);
-    console.log(roomId);
     socket.emit(SOCKET_EVENTS.CLIENT.EXECUTE_REQUEST, { roomId });
   };
 

--- a/packages/client/src/store/useAppStore.ts
+++ b/packages/client/src/store/useAppStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { nanoid } from "nanoid";
 
-import { IRequestData, IResponseData, HttpMethod, IKeyValue } from "@proxymity/shared";
+import { IRequestData, IResponseData, IServerError, HttpMethod, IKeyValue } from "@proxymity/shared";
 
 interface AppState {
   // State
@@ -9,6 +9,7 @@ interface AppState {
   response: IResponseData | null;
   isLoading: boolean;
   activeUsers: number;
+  serverError: IServerError | null;
 
   // Basic Actions
   setMethod: (method: HttpMethod) => void;
@@ -16,6 +17,7 @@ interface AppState {
   setBody: (body: string) => void;
   setResponse: (response: IResponseData | null) => void;
   setLoading: (isLoading: boolean) => void;
+  setServerError: (serverError: IServerError | null) => void;
   setRequest: (newRequest: IRequestData) => void;
   setActiveUsers: (count: number) => void;
   setHeaders: (headers: IKeyValue[]) => void;
@@ -44,6 +46,7 @@ export const useAppStore = create<AppState>()((set) => ({
   response: null,
   isLoading: false,
   activeUsers: 0,
+  serverError: null,
 
   setMethod: (method) =>
     set((state) => ({ request: { ...state.request, method } })),
@@ -56,6 +59,7 @@ export const useAppStore = create<AppState>()((set) => ({
 
   setResponse: (response) => set({ response }),
   setLoading: (isLoading) => set({ isLoading }),
+  setServerError: (serverError) => set({ serverError }),
   setRequest: (newRequest) => set({ request: newRequest }),
   setActiveUsers: (count) => set({ activeUsers: count }),
 

--- a/packages/server/src/handlers/request-handler.ts
+++ b/packages/server/src/handlers/request-handler.ts
@@ -29,8 +29,10 @@ const handleExecuteRequest = async (
     console.error(`[CRITICAL] Error executing request for room ${roomId}:`, criticalError);
     stateStore.setLoading(roomId, false);
     
-    io.to(roomId).emit(SOCKET_EVENTS.SERVER.ERROR, { 
-      message: 'Internal Proxy Error. Please try again.' 
+    const message = criticalError instanceof Error ? criticalError.message : 'Internal Proxy Error';
+    io.to(roomId).emit(SOCKET_EVENTS.SERVER.ERROR, {
+      message,
+      code: 'proxy_error'
     });
   }
 };

--- a/packages/server/src/handlers/room-handler.ts
+++ b/packages/server/src/handlers/room-handler.ts
@@ -104,7 +104,7 @@ export const registerRoomHandlers = (io: Server, socket: Socket) => {
   socket.on(SOCKET_EVENTS.CLIENT.JOIN_ROOM, (roomId: string) => {
     if (!roomId || typeof roomId !== 'string' || roomId.trim() === '') {
       console.warn(`[RoomHandler] Invalid roomId received from ${socket.id}`);
-      socket.emit(SOCKET_EVENTS.SERVER.ERROR, { message: "Invalid Room ID" });
+      socket.emit(SOCKET_EVENTS.SERVER.ERROR, { message: "Invalid Room ID", code: 'room_error' });
       return;
     }
     handleJoinRoom(io, socket, roomId);

--- a/packages/server/src/services/proxy-service.ts
+++ b/packages/server/src/services/proxy-service.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { IRequestData, IResponseData, IKeyValue } from '@proxymity/shared';
 
 /**
@@ -58,30 +58,12 @@ const createSuccessResponse = (
 });
 
 
-const createErrorResponse = (
-  error: unknown, 
-  durationMs: number
-): IResponseData => {
-  const isAxiosError = error instanceof AxiosError;
-  
-  return {
-    status: isAxiosError && error.response ? error.response.status : 0,
-    statusText: isAxiosError ? error.message : 'Unknown Internal Error',
-    data: isAxiosError && error.response ? error.response.data : null,
-    headers: {},
-    time: durationMs,
-    size: 0,
-    timestamp: Date.now(),
-  };
-};
-
-
 export const executeRequest = async (requestData: IRequestData): Promise<IResponseData> => {
   const startTime = Date.now();
 
   // Basic security check to prevent SSRF to localhost
   if (requestData.url.includes('localhost') || requestData.url.includes('127.0.0.1')) {
-     return createErrorResponse(new Error('Access to local resources is forbidden'), 0);
+    throw new Error('Access to local resources is forbidden');
   }
 
   const config: AxiosRequestConfig = {
@@ -91,13 +73,9 @@ export const executeRequest = async (requestData: IRequestData): Promise<IRespon
     params: mapHeadersToRecord(requestData.queryParams),
     data: parseRequestBody(requestData.body),
     validateStatus: () => true,
-    timeout: 10000, 
+    timeout: 10000,
   };
 
-  try {
-    const axiosResponse = await axios(config);
-    return createSuccessResponse(axiosResponse, Date.now() - startTime);
-  } catch (error) {
-    return createErrorResponse(error, Date.now() - startTime);
-  }
+  const axiosResponse = await axios(config);
+  return createSuccessResponse(axiosResponse, Date.now() - startTime);
 };

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -20,6 +20,6 @@ export const SOCKET_EVENTS = {
     BROADCAST_CHANGE: 'server:broadcast_change', 
     REQUEST_STARTED: 'server:request_started',   // "Loading..."
     REQUEST_COMPLETE: 'server:request_complete', // Payload: IResponseData
-    ERROR: 'server:error'                        // Payload: { message: string }
+    ERROR: 'server:error'                        // Payload: IServerError
   }
 } as const;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -31,7 +31,15 @@ export interface IResponseData {
   timestamp: number; // Cuándo ocurrió
 }
 
-// 5. El Estado Completo de la Sala
+// 5. Error del servidor
+export type ServerErrorCode = 'proxy_error' | 'room_error';
+
+export interface IServerError {
+  message: string;
+  code: ServerErrorCode;
+}
+
+// 6. El Estado Completo de la Sala
 export interface IRoomState {
   id: string;           // ID de la sala (ej: "room-abc")
   request: IRequestData;


### PR DESCRIPTION
## Summary
- **WorkspaceHeader**: brand name with DM Serif Display, teal dot indicator, room ID display, overlapping avatar pills with Minerale gradient colors
- **RequestControls**: `METHOD_STYLES` map with explicit hex colors per method, monospace inputs, Send icon replacing Play, transparent backgrounds
- **KeyValueTable**: uppercase column headers with letter-spacing, blue/off-white key/value inputs, dashed add-row button, refined delete button
- **ResponseViewer**: `STATUS_META` map for status badges, redesigned status bar with left accent, custom `mineraleTheme` syntax highlighting, success glow (2xx), teal loader, inline error display
- **App.tsx**: error screen with `min-page-enter` animation, serif heading, monospace error message

> **Depends on**: #27 (Minerale design system — fonts, palette, CSS utilities)
> **Depends on**: #26 (server:error handling — error state in store and response viewer)

## Test Plan
- [ ] Send a successful request and verify response status bar shows correct color and label
- [ ] Send a failing request and verify inline error displays in red
- [ ] Add headers/params and verify key (blue) vs value (off-white) coloring
- [ ] Verify workspace header shows room ID and avatar pills
- [ ] Confirm method selector color changes per HTTP method