### PR TITLE
POC: collaborative cursor presence system

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -5,15 +5,19 @@ import { RequestEditor } from "@/components/request-editor"
 import { ResponseViewer } from "@/components/response-viewer"
 import { useAppStore } from "@/store/useAppStore"
 import { useRoomConnection } from "@/hooks/useRoomConnection"
+import { CursorOverlay } from "@/components/CursorOverlay"
+import { usePresence } from "@/hooks/usePresence"
 
 function App() {
   const [roomId] = useState<string>("example-room-id");
   
   const { sendRequest } = useRoomConnection(roomId);
+  usePresence(roomId);
   const activeUsers = useAppStore((state) => state.activeUsers);
 
   return (
-    <div className="flex h-screen flex-col bg-background">
+    <div id="app-root" className="flex h-screen flex-col bg-background">
+      <CursorOverlay />
       <WorkspaceHeader roomId={roomId} activeUsers={activeUsers} />
 
       <div className="flex flex-1 flex-col overflow-hidden">

--- a/packages/client/src/components/CursorOverlay.tsx
+++ b/packages/client/src/components/CursorOverlay.tsx
@@ -1,0 +1,115 @@
+// packages/client/src/components/CursorOverlay.tsx
+
+import { useEffect, useRef, useState } from 'react';
+import { useAppStore } from '@/store/useAppStore';
+import type { ICursorPosition } from '@proxymity/shared';
+
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function CursorMarker({ cursor, fading }: { cursor: ICursorPosition; fading: boolean }) {
+  const x = cursor.x * 100;
+  const y = cursor.y * 100;
+  const flipLeft = cursor.x > 0.85;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: `${x}%`,
+        top: `${y}%`,
+        transition: 'left 80ms ease-out, top 80ms ease-out, opacity 400ms ease',
+        opacity: fading ? 0 : 1,
+        pointerEvents: 'none',
+        userSelect: 'none',
+      }}
+    >
+      {/* Cursor arrow SVG */}
+      <svg width="12" height="16" viewBox="0 0 12 16" fill="none">
+        <path
+          d="M1 1 L1 13 L4 9.5 L7 15.5 L8.5 14.8 L5.5 8.5 L10.5 8.5 Z"
+          fill={cursor.color}
+          fillOpacity={0.9}
+          stroke={cursor.color}
+          strokeWidth="0.5"
+          strokeOpacity={0.35}
+        />
+      </svg>
+
+      {/* Username pill */}
+      <div
+        style={{
+          position: 'absolute',
+          top: '14px',
+          ...(flipLeft ? { right: '10px' } : { left: '10px' }),
+          backgroundColor: hexToRgba(cursor.color, 0.12),
+          border: `1px solid ${hexToRgba(cursor.color, 0.28)}`,
+          color: cursor.color,
+          borderRadius: '3px',
+          padding: '1px 6px',
+          fontSize: '10px',
+          fontFamily: '"JetBrains Mono", monospace',
+          whiteSpace: 'nowrap',
+          lineHeight: '16px',
+        }}
+      >
+        {cursor.username}
+      </div>
+    </div>
+  );
+}
+
+export function CursorOverlay() {
+  const presenceCursors = useAppStore((state) => state.presenceCursors);
+  const [fadingCursors, setFadingCursors] = useState<Record<string, ICursorPosition>>({});
+  const prevRef = useRef<Record<string, ICursorPosition>>({});
+
+  useEffect(() => {
+    const prev = prevRef.current;
+    const removed = Object.keys(prev).filter((id) => !presenceCursors[id]);
+
+    if (removed.length > 0) {
+      const toFade: Record<string, ICursorPosition> = {};
+      removed.forEach((id) => { toFade[id] = prev[id]; });
+      setFadingCursors((f) => ({ ...f, ...toFade }));
+
+      const timer = setTimeout(() => {
+        setFadingCursors((f) => {
+          const next = { ...f };
+          removed.forEach((id) => delete next[id]);
+          return next;
+        });
+      }, 420);
+
+      prevRef.current = presenceCursors;
+      return () => clearTimeout(timer);
+    }
+
+    prevRef.current = presenceCursors;
+  }, [presenceCursors]);
+
+  const activeCursors = Object.values(presenceCursors);
+  const staleCursors = Object.values(fadingCursors).filter((c) => !presenceCursors[c.userId]);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        pointerEvents: 'none',
+        zIndex: 9998,
+      }}
+    >
+      {activeCursors.map((cursor) => (
+        <CursorMarker key={cursor.userId} cursor={cursor} fading={false} />
+      ))}
+      {staleCursors.map((cursor) => (
+        <CursorMarker key={`fading-${cursor.userId}`} cursor={cursor} fading={true} />
+      ))}
+    </div>
+  );
+}

--- a/packages/client/src/components/CursorOverlay.tsx
+++ b/packages/client/src/components/CursorOverlay.tsx
@@ -71,25 +71,23 @@ export function CursorOverlay() {
   useEffect(() => {
     const prev = prevRef.current;
     const removed = Object.keys(prev).filter((id) => !presenceCursors[id]);
-
-    if (removed.length > 0) {
-      const toFade: Record<string, ICursorPosition> = {};
-      removed.forEach((id) => { toFade[id] = prev[id]; });
-      setFadingCursors((f) => ({ ...f, ...toFade }));
-
-      const timer = setTimeout(() => {
-        setFadingCursors((f) => {
-          const next = { ...f };
-          removed.forEach((id) => delete next[id]);
-          return next;
-        });
-      }, 420);
-
-      prevRef.current = presenceCursors;
-      return () => clearTimeout(timer);
-    }
-
     prevRef.current = presenceCursors;
+
+    if (removed.length === 0) return;
+
+    const toFade: Record<string, ICursorPosition> = {};
+    removed.forEach((id) => { toFade[id] = prev[id]; });
+    setFadingCursors((f) => ({ ...f, ...toFade }));
+
+    const timer = setTimeout(() => {
+      setFadingCursors((f) => {
+        const next = { ...f };
+        removed.forEach((id) => delete next[id]);
+        return next;
+      });
+    }, 420);
+
+    return () => clearTimeout(timer);
   }, [presenceCursors]);
 
   const activeCursors = Object.values(presenceCursors);

--- a/packages/client/src/components/request-editor.tsx
+++ b/packages/client/src/components/request-editor.tsx
@@ -1,9 +1,21 @@
+import { useEffect, useRef } from 'react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { KeyValueTable } from "@/components/key-value-table"
 import { useAppStore } from "@/store/useAppStore"
-import Editor, { type BeforeMount } from "@monaco-editor/react"
+import Editor, { type BeforeMount, type OnMount, type Monaco } from "@monaco-editor/react"
 import { socket } from "@/services/socket"
 import { SOCKET_EVENTS } from "@proxymity/shared"
+import type { IEditorCursor } from "@proxymity/shared"
+
+type MonacoEditor = Parameters<OnMount>[0];
+type IContentWidget = Parameters<MonacoEditor['addContentWidget']>[0];
+
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
 
 interface RequestEditorProps {
   roomId: string;
@@ -33,6 +45,109 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
   const addQueryParam = useAppStore((state) => state.addQueryParam);
   const removeQueryParam = useAppStore((state) => state.removeQueryParam);
   const updateQueryParam = useAppStore((state) => state.updateQueryParam);
+
+  const editorCursors = useAppStore((state) => state.editorCursors);
+  const editorRef = useRef<MonacoEditor | null>(null);
+  const monacoRef = useRef<Monaco | null>(null);
+  const widgetsRef = useRef<Map<string, IContentWidget>>(new Map());
+  const editorRafRef = useRef<number | null>(null);
+
+  const handleEditorMount: OnMount = (editor, monacoInstance) => {
+    editorRef.current = editor;
+    monacoRef.current = monacoInstance;
+
+    editor.onDidChangeCursorPosition((e) => {
+      if (editorRafRef.current !== null) return;
+      editorRafRef.current = requestAnimationFrame(() => {
+        emitWithConnection(SOCKET_EVENTS.CLIENT.EDITOR_CURSOR_CHANGE, {
+          roomId,
+          lineNumber: e.position.lineNumber,
+          column: e.position.column,
+        });
+        editorRafRef.current = null;
+      });
+    });
+  };
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    const monacoInstance = monacoRef.current;
+    if (!monacoInstance) return;
+
+    const currentIds = new Set(Object.keys(editorCursors));
+    const existingIds = new Set(widgetsRef.current.keys());
+
+    // Remove widgets for users who left
+    existingIds.forEach((id) => {
+      if (!currentIds.has(id)) {
+        editor.removeContentWidget(widgetsRef.current.get(id)!);
+        widgetsRef.current.delete(id);
+      }
+    });
+
+    // Add or update widgets for current users
+    currentIds.forEach((id) => {
+      const cursor: IEditorCursor = editorCursors[id];
+
+      // Remove old widget for this user before re-adding at new position
+      if (widgetsRef.current.has(id)) {
+        editor.removeContentWidget(widgetsRef.current.get(id)!);
+      }
+
+      const domNode = document.createElement('div');
+      domNode.style.cssText = 'display:flex;flex-direction:column;align-items:flex-start;pointer-events:none;';
+
+      const label = document.createElement('div');
+      label.textContent = cursor.username;
+      label.style.cssText = `
+        background-color: ${hexToRgba(cursor.color, 0.12)};
+        border: 1px solid ${hexToRgba(cursor.color, 0.28)};
+        color: ${cursor.color};
+        border-radius: 3px;
+        padding: 0 5px;
+        font-size: 10px;
+        font-family: "JetBrains Mono", monospace;
+        white-space: nowrap;
+        line-height: 16px;
+        margin-bottom: 1px;
+      `;
+
+      const line = document.createElement('div');
+      line.style.cssText = `
+        width: 2px;
+        height: 18px;
+        background-color: ${cursor.color};
+        opacity: 0.8;
+      `;
+
+      domNode.appendChild(label);
+      domNode.appendChild(line);
+
+      const widget: IContentWidget = {
+        getId: () => `presence-cursor-${id}`,
+        getDomNode: () => domNode,
+        getPosition: () => ({
+          position: { lineNumber: cursor.lineNumber, column: cursor.column },
+          preference: [monacoInstance.editor.ContentWidgetPositionPreference.EXACT],
+        }),
+      };
+
+      editor.addContentWidget(widget);
+      widgetsRef.current.set(id, widget);
+    });
+  }, [editorCursors]);
+
+  useEffect(() => {
+    return () => {
+      const editor = editorRef.current;
+      if (!editor) return;
+      widgetsRef.current.forEach((widget) => editor.removeContentWidget(widget));
+      widgetsRef.current.clear();
+      if (editorRafRef.current !== null) cancelAnimationFrame(editorRafRef.current);
+    };
+  }, []);
 
   const emitWithConnection = (event: string, data: any) => {
     if (socket.connected) {
@@ -111,6 +226,7 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
                 onChange={handleBodyChange}
                 theme="proxymity-dark"
                 beforeMount={handleEditorWillMount}
+                onMount={handleEditorMount}
                 options={{
                   minimap: { enabled: false },
                   fontSize: 14,

--- a/packages/client/src/hooks/usePresence.ts
+++ b/packages/client/src/hooks/usePresence.ts
@@ -1,0 +1,106 @@
+// packages/client/src/hooks/usePresence.ts
+
+import { useEffect, useRef } from 'react';
+import { socket } from '@/services/socket';
+import { SOCKET_EVENTS } from '@proxymity/shared';
+import type { ICursorPosition, IEditorCursor, IPresenceUser } from '@proxymity/shared';
+import { useAppStore } from '@/store/useAppStore';
+
+export function usePresence(roomId: string) {
+  const setPresenceCursor = useAppStore((state) => state.setPresenceCursor);
+  const removePresenceCursor = useAppStore((state) => state.removePresenceCursor);
+  const setEditorCursor = useAppStore((state) => state.setEditorCursor);
+  const removeEditorCursor = useAppStore((state) => state.removeEditorCursor);
+  const setMyIdentity = useAppStore((state) => state.setMyIdentity);
+
+  const rafRef = useRef<number | null>(null);
+  const pendingPos = useRef<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    // ── Mouse tracking (throttled via rAF) ───────────────────
+    const handleMouseMove = (e: MouseEvent) => {
+      // Use the root app div as coordinate space
+      const container = document.getElementById('app-root');
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      pendingPos.current = {
+        x: Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width)),
+        y: Math.min(1, Math.max(0, (e.clientY - rect.top) / rect.height)),
+      };
+      if (rafRef.current === null) {
+        rafRef.current = requestAnimationFrame(() => {
+          if (pendingPos.current && socket.connected) {
+            socket.emit(SOCKET_EVENTS.CLIENT.CURSOR_MOVE, {
+              roomId,
+              x: pendingPos.current.x,
+              y: pendingPos.current.y,
+            });
+          }
+          pendingPos.current = null;
+          rafRef.current = null;
+        });
+      }
+    };
+
+    const handleMouseLeave = () => {
+      if (socket.connected) {
+        socket.emit(SOCKET_EVENTS.CLIENT.CURSOR_LEAVE, { roomId });
+      }
+    };
+
+    // ── Socket listeners ──────────────────────────────────────
+    const onPresenceInit = ({
+      self,
+    }: {
+      self: IPresenceUser;
+      users: IPresenceUser[];
+    }) => {
+      setMyIdentity(self);
+      // `users` are existing room members — their cursors will arrive via CURSOR_UPDATE
+      // as they move. No need to pre-populate cursor positions.
+    };
+
+    const onCursorUpdate = (cursor: ICursorPosition) => {
+      setPresenceCursor(cursor);
+    };
+
+    const onCursorRemoved = ({ userId }: { userId: string }) => {
+      removePresenceCursor(userId);
+      removeEditorCursor(userId);
+    };
+
+    const onEditorCursorUpdate = (cursor: IEditorCursor) => {
+      setEditorCursor(cursor);
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseleave', handleMouseLeave);
+    socket.on(SOCKET_EVENTS.SERVER.PRESENCE_INIT, onPresenceInit);
+    socket.on(SOCKET_EVENTS.SERVER.CURSOR_UPDATE, onCursorUpdate);
+    socket.on(SOCKET_EVENTS.SERVER.CURSOR_REMOVED, onCursorRemoved);
+    socket.on(SOCKET_EVENTS.SERVER.EDITOR_CURSOR_UPDATE, onEditorCursorUpdate);
+
+    // ── Inactivity eviction (every 1s, remove cursors older than 3s) ──
+    const evictionInterval = setInterval(() => {
+      const cursors = useAppStore.getState().presenceCursors;
+      const now = Date.now();
+      Object.values(cursors).forEach((cursor) => {
+        if (now - cursor.updatedAt > 3000) {
+          removePresenceCursor(cursor.userId);
+          removeEditorCursor(cursor.userId);
+        }
+      });
+    }, 1000);
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseleave', handleMouseLeave);
+      socket.off(SOCKET_EVENTS.SERVER.PRESENCE_INIT, onPresenceInit);
+      socket.off(SOCKET_EVENTS.SERVER.CURSOR_UPDATE, onCursorUpdate);
+      socket.off(SOCKET_EVENTS.SERVER.CURSOR_REMOVED, onCursorRemoved);
+      socket.off(SOCKET_EVENTS.SERVER.EDITOR_CURSOR_UPDATE, onEditorCursorUpdate);
+      clearInterval(evictionInterval);
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [roomId, setPresenceCursor, removePresenceCursor, setEditorCursor, removeEditorCursor, setMyIdentity]);
+}

--- a/packages/client/src/store/useAppStore.ts
+++ b/packages/client/src/store/useAppStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { nanoid } from "nanoid";
 
-import { IRequestData, IResponseData, HttpMethod, IKeyValue } from "@proxymity/shared";
+import type { IRequestData, IResponseData, HttpMethod, IKeyValue, ICursorPosition, IEditorCursor, IPresenceUser } from "@proxymity/shared";
 
 interface AppState {
   // State
@@ -9,6 +9,17 @@ interface AppState {
   response: IResponseData | null;
   isLoading: boolean;
   activeUsers: number;
+
+  // Presence
+  presenceCursors: Record<string, ICursorPosition>;
+  editorCursors: Record<string, IEditorCursor>;
+  myIdentity: IPresenceUser | null;
+
+  setPresenceCursor: (cursor: ICursorPosition) => void;
+  removePresenceCursor: (userId: string) => void;
+  setEditorCursor: (cursor: IEditorCursor) => void;
+  removeEditorCursor: (userId: string) => void;
+  setMyIdentity: (user: IPresenceUser) => void;
 
   // Basic Actions
   setMethod: (method: HttpMethod) => void;
@@ -44,6 +55,35 @@ export const useAppStore = create<AppState>()((set) => ({
   response: null,
   isLoading: false,
   activeUsers: 0,
+  presenceCursors: {},
+  editorCursors: {},
+  myIdentity: null,
+
+  setPresenceCursor: (cursor) =>
+    set((state) => ({
+      presenceCursors: { ...state.presenceCursors, [cursor.userId]: cursor },
+    })),
+
+  removePresenceCursor: (userId) =>
+    set((state) => {
+      const next = { ...state.presenceCursors };
+      delete next[userId];
+      return { presenceCursors: next };
+    }),
+
+  setEditorCursor: (cursor) =>
+    set((state) => ({
+      editorCursors: { ...state.editorCursors, [cursor.userId]: cursor },
+    })),
+
+  removeEditorCursor: (userId) =>
+    set((state) => {
+      const next = { ...state.editorCursors };
+      delete next[userId];
+      return { editorCursors: next };
+    }),
+
+  setMyIdentity: (user) => set({ myIdentity: user }),
 
   setMethod: (method) =>
     set((state) => ({ request: { ...state.request, method } })),

--- a/packages/server/src/handlers/presence-handler.ts
+++ b/packages/server/src/handlers/presence-handler.ts
@@ -33,4 +33,11 @@ export const registerPresenceHandlers = (io: Server, socket: Socket) => {
       });
     }
   );
+
+  socket.on('disconnect', () => {
+    const roomId = socket.data.roomId as string | undefined;
+    if (roomId) {
+      socket.to(roomId).emit(SOCKET_EVENTS.SERVER.CURSOR_REMOVED, { userId: socket.id });
+    }
+  });
 };

--- a/packages/server/src/handlers/presence-handler.ts
+++ b/packages/server/src/handlers/presence-handler.ts
@@ -1,0 +1,36 @@
+// packages/server/src/handlers/presence-handler.ts
+
+import { Server, Socket } from 'socket.io';
+import { SOCKET_EVENTS } from '@proxymity/shared';
+
+export const registerPresenceHandlers = (io: Server, socket: Socket) => {
+  socket.on(SOCKET_EVENTS.CLIENT.CURSOR_MOVE, ({ roomId, x, y }: { roomId: string; x: number; y: number }) => {
+    if (!socket.data.username || !socket.data.color) return;
+    socket.to(roomId).emit(SOCKET_EVENTS.SERVER.CURSOR_UPDATE, {
+      userId: socket.id,
+      username: socket.data.username,
+      color: socket.data.color,
+      x,
+      y,
+      updatedAt: Date.now(),
+    });
+  });
+
+  socket.on(SOCKET_EVENTS.CLIENT.CURSOR_LEAVE, ({ roomId }: { roomId: string }) => {
+    socket.to(roomId).emit(SOCKET_EVENTS.SERVER.CURSOR_REMOVED, { userId: socket.id });
+  });
+
+  socket.on(
+    SOCKET_EVENTS.CLIENT.EDITOR_CURSOR_CHANGE,
+    ({ roomId, lineNumber, column }: { roomId: string; lineNumber: number; column: number }) => {
+      if (!socket.data.username || !socket.data.color) return;
+      socket.to(roomId).emit(SOCKET_EVENTS.SERVER.EDITOR_CURSOR_UPDATE, {
+        userId: socket.id,
+        username: socket.data.username,
+        color: socket.data.color,
+        lineNumber,
+        column,
+      });
+    }
+  );
+};

--- a/packages/server/src/handlers/room-handler.ts
+++ b/packages/server/src/handlers/room-handler.ts
@@ -1,24 +1,60 @@
 import { Server, Socket } from 'socket.io';
-import { SOCKET_EVENTS, HttpMethod, IKeyValue } from '@proxymity/shared';
+import { SOCKET_EVENTS, HttpMethod, IKeyValue, IPresenceUser } from '@proxymity/shared';
 import { stateStore } from '../services/state-store';
+import { generateUsername, assignColor } from '../utils/username-generator';
 
 
 const handleJoinRoom = (io: Server, socket: Socket, roomId: string) => {
   socket.join(roomId);
-  
+
   const userCount = io.sockets.adapter.rooms.get(roomId)?.size || 0;
   stateStore.updateUserCount(roomId, userCount);
-  
-  const currentState = stateStore.getOrCreateRoom(roomId);
 
+  // Assign presence identity (stored in socket.data for the session)
+  socket.data.username = generateUsername();
+  socket.data.color = assignColor(userCount - 1); // -1 because this socket just joined
+  socket.data.roomId = roomId;
+
+  const currentState = stateStore.getOrCreateRoom(roomId);
   socket.emit(SOCKET_EVENTS.SERVER.SYNC_STATE, currentState);
   io.to(roomId).emit(SOCKET_EVENTS.SERVER.USER_COUNT, userCount);
 
-  console.log(`[Room] ${socket.id} joined ${roomId}. State synced.`);
+  // Build list of users already in the room (excluding the socket that just joined)
+  const roomSockets = io.sockets.adapter.rooms.get(roomId);
+  const existingUsers: IPresenceUser[] = [];
+  if (roomSockets) {
+    for (const sid of roomSockets) {
+      if (sid === socket.id) continue;
+      const s = io.sockets.sockets.get(sid);
+      if (s?.data.username && s?.data.color) {
+        existingUsers.push({ userId: sid, username: s.data.username, color: s.data.color });
+      }
+    }
+  }
+
+  // Send joiner their own identity + who's already here
+  socket.emit(SOCKET_EVENTS.SERVER.PRESENCE_INIT, {
+    self: { userId: socket.id, username: socket.data.username, color: socket.data.color },
+    users: existingUsers,
+  });
+
+  // Tell the rest of the room someone new arrived
+  socket.to(roomId).emit(SOCKET_EVENTS.SERVER.USER_JOINED, {
+    userId: socket.id,
+    username: socket.data.username,
+    color: socket.data.color,
+  });
+
+  console.log(`[Room] ${socket.id} (${socket.data.username}) joined ${roomId}.`);
 };
 
 const handleLeaveRoom = (io: Server, socket: Socket, roomId: string) => {
   if (!roomId || typeof roomId !== 'string') return;
+
+  if (socket.data.roomId === roomId) {
+    socket.to(roomId).emit(SOCKET_EVENTS.SERVER.CURSOR_REMOVED, { userId: socket.id });
+    socket.data.roomId = undefined;
+  }
 
   socket.leave(roomId);
 
@@ -39,8 +75,9 @@ const handleDisconnecting = (io: Server, socket: Socket) => {
       const newCount = currentSize - 1;
 
       stateStore.updateUserCount(roomId, newCount);
-      
+
       io.to(roomId).emit(SOCKET_EVENTS.SERVER.USER_COUNT, newCount);
+      io.to(roomId).emit(SOCKET_EVENTS.SERVER.CURSOR_REMOVED, { userId: socket.id });
     }
   }
 };

--- a/packages/server/src/handlers/room-handler.ts
+++ b/packages/server/src/handlers/room-handler.ts
@@ -77,7 +77,6 @@ const handleDisconnecting = (io: Server, socket: Socket) => {
       stateStore.updateUserCount(roomId, newCount);
 
       io.to(roomId).emit(SOCKET_EVENTS.SERVER.USER_COUNT, newCount);
-      io.to(roomId).emit(SOCKET_EVENTS.SERVER.CURSOR_REMOVED, { userId: socket.id });
     }
   }
 };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ import dotenv from 'dotenv';
 
 import { registerRequestHandlers } from './handlers/request-handler';
 import { registerRoomHandlers } from './handlers/room-handler';
+import { registerPresenceHandlers } from './handlers/presence-handler';
 
 dotenv.config();
 
@@ -33,6 +34,7 @@ io.on('connection', (socket) => {
 
   registerRoomHandlers(io, socket);
   registerRequestHandlers(io, socket);
+  registerPresenceHandlers(io, socket);
 
   socket.on('disconnect', (reason) => {
     console.log(`[Socket] Client disconnected: ${socket.id} (Reason: ${reason})`);

--- a/packages/server/src/utils/username-generator.ts
+++ b/packages/server/src/utils/username-generator.ts
@@ -1,0 +1,24 @@
+// packages/server/src/utils/username-generator.ts
+
+const ADJECTIVES = [
+  'swift', 'jade', 'calm', 'pale', 'cool', 'dusk', 'iron', 'mild',
+  'keen', 'bold', 'teal', 'slate', 'ash', 'dim', 'soft', 'gold',
+  'grey', 'blue', 'dark', 'warm', 'prim', 'wry', 'sage', 'grim',
+];
+
+const ANIMALS = [
+  'falcon', 'otter', 'lynx', 'crane', 'fox', 'elk', 'wolf', 'hawk',
+  'seal', 'mink', 'hare', 'deer', 'owl', 'bear', 'crow',
+];
+
+export const PRESENCE_COLORS = ['#3D8F82', '#4A9E6E', '#5A8FC0', '#8C7BC4'];
+
+export function generateUsername(): string {
+  const adj = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
+  const animal = ANIMALS[Math.floor(Math.random() * ANIMALS.length)];
+  return `${adj}-${animal}`;
+}
+
+export function assignColor(currentRoomSize: number): string {
+  return PRESENCE_COLORS[currentRoomSize % PRESENCE_COLORS.length];
+}

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -5,21 +5,33 @@ export const SOCKET_EVENTS = {
     JOIN_ROOM: 'client:join_room',
     LEAVE_ROOM: 'client:leave_room',
 
-    UPDATE_METHOD: 'client:update_method', // Payload: "GET" | "POST"
-    UPDATE_URL: 'client:update_url',       // Payload: string
-    UPDATE_HEADERS: 'client:update_headers',   // Payload: IKeyValue[]
-    UPDATE_PARAMS: 'client:update_params',     // Payload: IKeyValue[]
-    UPDATE_BODY: 'client:update_body',         // Payload: string (JSON)
+    UPDATE_METHOD: 'client:update_method',
+    UPDATE_URL: 'client:update_url',
+    UPDATE_HEADERS: 'client:update_headers',
+    UPDATE_PARAMS: 'client:update_params',
+    UPDATE_BODY: 'client:update_body',
 
-    EXECUTE_REQUEST: 'client:execute_request', // Payload: IRequestData (opcional, o usa el estado del server)
+    EXECUTE_REQUEST: 'client:execute_request',
+
+    // Presence
+    CURSOR_MOVE: 'client:cursor_move',                   // { roomId, x, y }
+    CURSOR_LEAVE: 'client:cursor_leave',                 // { roomId }
+    EDITOR_CURSOR_CHANGE: 'client:editor_cursor_change', // { roomId, lineNumber, column }
   },
-  
+
   SERVER: {
     SYNC_STATE: 'server:sync_state',     // Payload: IRoomState completo
     USER_COUNT: 'server:user_count',     // Payload: number
-    BROADCAST_CHANGE: 'server:broadcast_change', 
+    BROADCAST_CHANGE: 'server:broadcast_change',
     REQUEST_STARTED: 'server:request_started',   // "Loading..."
     REQUEST_COMPLETE: 'server:request_complete', // Payload: IResponseData
-    ERROR: 'server:error'                        // Payload: { message: string }
-  }
+    ERROR: 'server:error',                       // Payload: IServerError
+
+    // Presence
+    PRESENCE_INIT: 'server:presence_init',               // { self: IPresenceUser, users: IPresenceUser[] }
+    USER_JOINED: 'server:user_joined',                   // IPresenceUser
+    CURSOR_UPDATE: 'server:cursor_update',               // ICursorPosition
+    CURSOR_REMOVED: 'server:cursor_removed',             // { userId: string }
+    EDITOR_CURSOR_UPDATE: 'server:editor_cursor_update', // IEditorCursor
+  },
 } as const;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -39,3 +39,22 @@ export interface IRoomState {
   activeUsers: number;  // Cuántos devs hay conectados
   isLoading: boolean;   // Si está cargando una petición
 }
+
+// 7. Presence / Collaborative cursors
+
+export interface IPresenceUser {
+  userId: string;    // socket.id — source of truth for identity
+  username: string;  // "swift-falcon" — display label only
+  color: string;     // "#3D8F82" — hex color assigned on join
+}
+
+export interface ICursorPosition extends IPresenceUser {
+  x: number;         // 0–1, fraction of app container width
+  y: number;         // 0–1, fraction of app container height
+  updatedAt: number; // Date.now() — used for 3s inactivity eviction
+}
+
+export interface IEditorCursor extends IPresenceUser {
+  lineNumber: number;
+  column: number;
+}


### PR DESCRIPTION
## Summary
- Adds real-time presence system: each user gets a generated username (e.g. "swift-falcon") and a unique color on join
- Broadcasts cursor positions across the room via `client:cursor_move` / `server:cursor_update` events
- Renders remote cursors as floating colored labels via `CursorOverlay` component (fractional x/y coordinates)
- Tracks Monaco editor cursor positions via `client:editor_cursor_change` / `server:editor_cursor_update` events and renders them as `ContentWidget` decorations inside the editor
- Adds `usePresence` hook that wires cursor tracking, socket relay, and store updates
- Server: `presence-handler.ts` relays cursor events within a room; `room-handler.ts` assigns identity on join and cleans up on disconnect; `username-generator.ts` produces random readable usernames with assigned palette colors
- Zustand store: adds `presenceCursors`, `editorCursors`, `myIdentity` slices with corresponding actions

## Architecture
```
User moves mouse → usePresence → socket emit client:cursor_move
                                    ↓
                             server relays to room
                                    ↓
                     other clients receive server:cursor_update
                                    ↓
                    store.setPresenceCursor → CursorOverlay re-renders
```

## Test Plan
- [ ] Open two browser tabs in the same room, move the mouse in one — verify a labeled cursor appears in the other
- [ ] Move the Monaco editor cursor — verify editor cursor decoration appears for the other user
- [ ] Close a tab — verify the cursor disappears from the other tab within ~1s
- [ ] Verify assigned username and color persist for the duration of a session

> **Note**: This PR is independent of the Minerale UI changes (#27, #28) and can be merged in any order.