### PR TITLE
refactor: extract emitWithConnection to shared hook

### DIFF
--- a/packages/client/src/components/key-value-table.tsx
+++ b/packages/client/src/components/key-value-table.tsx
@@ -10,9 +10,10 @@ interface KeyValueTableProps {
   onUpdate: (id: string, field: keyof IKeyValue, value: string | boolean) => void;
   onDelete: (id: string) => void;
   placeholder?: string
+  disabled?: boolean
 }
 
-export function KeyValueTable({ items, onAdd, onDelete, onUpdate, placeholder = "Key" }: KeyValueTableProps) {
+export function KeyValueTable({ items, onAdd, onDelete, onUpdate, placeholder = "Key", disabled = false }: KeyValueTableProps) {
   
   return (
     <div className="space-y-2">
@@ -28,6 +29,7 @@ export function KeyValueTable({ items, onAdd, onDelete, onUpdate, placeholder = 
           <Checkbox
             checked={item.isEnabled}
             onCheckedChange={(checked) => onUpdate(item.id, "isEnabled", checked === true)}
+            disabled={disabled}
           />
           <Input
             type="text"
@@ -35,7 +37,7 @@ export function KeyValueTable({ items, onAdd, onDelete, onUpdate, placeholder = 
             value={item.key}
             onChange={(e) => onUpdate(item.id, "key", e.target.value)}
             className="font-mono text-sm"
-            disabled={!item.isEnabled}
+            disabled={disabled || !item.isEnabled}
           />
           <Input
             type="text"
@@ -43,15 +45,15 @@ export function KeyValueTable({ items, onAdd, onDelete, onUpdate, placeholder = 
             value={item.value}
             onChange={(e) => onUpdate(item.id, "value", e.target.value)}
             className="font-mono text-sm"
-            disabled={!item.isEnabled}
+            disabled={disabled || !item.isEnabled}
           />
-          <Button variant="ghost" size="icon" onClick={() => onDelete(item.id)} className="h-8 w-8">
+          <Button variant="ghost" size="icon" onClick={() => onDelete(item.id)} className="h-8 w-8" disabled={disabled}>
             <Trash2 className="h-4 w-4 text-muted-foreground hover:text-destructive" />
           </Button>
         </div>
       ))}
 
-      <Button variant="outline" size="sm" onClick={onAdd} className="w-full gap-2 mt-4 bg-transparent">
+      <Button variant="outline" size="sm" onClick={onAdd} className="w-full gap-2 mt-4 bg-transparent" disabled={disabled}>
         <Plus className="h-4 w-4" />
         Add {placeholder}
       </Button>

--- a/packages/client/src/components/request-controls.tsx
+++ b/packages/client/src/components/request-controls.tsx
@@ -4,7 +4,7 @@ import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { HttpMethod, SOCKET_EVENTS } from "@proxymity/shared"
 import { useAppStore } from "@/store/useAppStore"
-import { socket } from "@/services/socket"
+import { useSocketEmit } from "@/hooks/useSocketEmit"
 
 interface RequestControlsProps {
   roomId: string;
@@ -27,15 +27,7 @@ export function RequestControls({ roomId, onSend }: RequestControlsProps) {
   const setUrl = useAppStore((state) => state.setUrl);
   const setMethod = useAppStore((state) => state.setMethod);
 
-  const emitWithConnection = (event: string, data: any) => {
-    if (socket.connected) {
-      socket.emit(event, data);
-    } else {
-      socket.once('connect', () => {
-        socket.emit(event, data);
-      });
-    }
-  }
+  const emitWithConnection = useSocketEmit();
 
   const handleMethodChange = (newMethod: HttpMethod) => {
     setMethod(newMethod);

--- a/packages/client/src/components/request-controls.tsx
+++ b/packages/client/src/components/request-controls.tsx
@@ -5,6 +5,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { HttpMethod, SOCKET_EVENTS } from "@proxymity/shared"
 import { useAppStore } from "@/store/useAppStore"
 import { useSocketEmit } from "@/hooks/useSocketEmit"
+import { useSocketConnected } from "@/hooks/useSocketConnected"
 
 interface RequestControlsProps {
   roomId: string;
@@ -27,6 +28,7 @@ export function RequestControls({ roomId, onSend }: RequestControlsProps) {
   const setUrl = useAppStore((state) => state.setUrl);
   const setMethod = useAppStore((state) => state.setMethod);
 
+  const isConnected = useSocketConnected();
   const emitWithConnection = useSocketEmit();
 
   const handleMethodChange = (newMethod: HttpMethod) => {
@@ -45,6 +47,7 @@ export function RequestControls({ roomId, onSend }: RequestControlsProps) {
       <Select
         value={method}
         onValueChange={handleMethodChange}
+        disabled={!isConnected}
       >
         <SelectTrigger className={`w-32 font-semibold ${METHOD_COLORS[method]}`}>
           <SelectValue />
@@ -70,9 +73,10 @@ export function RequestControls({ roomId, onSend }: RequestControlsProps) {
         value={url}
         onChange={handleUrlChange}
         className="flex-1 font-mono text-sm"
+        disabled={!isConnected}
       />
 
-      <Button onClick={onSend} disabled={isLoading} className="gap-2 min-w-28" size="default">
+      <Button onClick={onSend} disabled={!isConnected || isLoading} className="gap-2 min-w-28" size="default">
         {isLoading ? (
           <Loader2 className="h-4 w-4 animate-spin" /> // Loading spinner
         ) : (

--- a/packages/client/src/components/request-editor.tsx
+++ b/packages/client/src/components/request-editor.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "@/store/useAppStore"
 import Editor, { type BeforeMount } from "@monaco-editor/react"
 import { SOCKET_EVENTS } from "@proxymity/shared"
 import { useSocketEmit } from "@/hooks/useSocketEmit"
+import { useSocketConnected } from "@/hooks/useSocketConnected"
 
 interface RequestEditorProps {
   roomId: string;
@@ -24,6 +25,7 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
   const body = useAppStore((state) => state.request.body);
   const headers = useAppStore((state) => state.request.headers);
   const queryParams = useAppStore((state) => state.request.queryParams);
+  const isConnected = useSocketConnected();
   
   const setBody = useAppStore((state) => state.setBody);
   const addHeader = useAppStore((state) => state.addHeader);
@@ -78,6 +80,7 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
             onUpdate={(id, field, value) => handleParamsChange(() => updateQueryParam(id, field, value))}
             onDelete={(id) => handleParamsChange(() => removeQueryParam(id))}
             placeholder="Query Parameter"
+            disabled={!isConnected}
           />
         </TabsContent>
 
@@ -88,6 +91,7 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
             onUpdate={(id, field, value) => handleHeadersChange(() => updateHeader(id, field, value))}
             onDelete={(id) => handleHeadersChange(() => removeHeader(id))}
             placeholder="Header"
+            disabled={!isConnected}
           />
         </TabsContent>
 
@@ -114,6 +118,7 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
                   formatOnType: true,
                   fontFamily: 'var(--font-mono)',
                   renderLineHighlight: "none",
+                  readOnly: !isConnected,
                   scrollbar: {
                     vertical: "auto",
                     horizontal: "auto",

--- a/packages/client/src/components/request-editor.tsx
+++ b/packages/client/src/components/request-editor.tsx
@@ -2,8 +2,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { KeyValueTable } from "@/components/key-value-table"
 import { useAppStore } from "@/store/useAppStore"
 import Editor, { type BeforeMount } from "@monaco-editor/react"
-import { socket } from "@/services/socket"
 import { SOCKET_EVENTS } from "@proxymity/shared"
+import { useSocketEmit } from "@/hooks/useSocketEmit"
 
 interface RequestEditorProps {
   roomId: string;
@@ -34,15 +34,7 @@ export function RequestEditor({ roomId }: RequestEditorProps) {
   const removeQueryParam = useAppStore((state) => state.removeQueryParam);
   const updateQueryParam = useAppStore((state) => state.updateQueryParam);
 
-  const emitWithConnection = (event: string, data: any) => {
-    if (socket.connected) {
-      socket.emit(event, data);
-    } else {
-      socket.once('connect', () => {
-        socket.emit(event, data);
-      });
-    }
-  }
+  const emitWithConnection = useSocketEmit();
 
   const handleBodyChange = (newBody: string | undefined) => {
     const bodyContent = newBody || "";

--- a/packages/client/src/hooks/useRoomConnection.ts
+++ b/packages/client/src/hooks/useRoomConnection.ts
@@ -65,7 +65,7 @@ export const useRoomConnection = (roomId: string) => {
 
     if (socket.connected) {
       onConnect();
-    } 
+    }
 
     return () => {
       socket.off('connect', onConnect);

--- a/packages/client/src/hooks/useSocketConnected.ts
+++ b/packages/client/src/hooks/useSocketConnected.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import { socket } from "@/services/socket";
+
+export const useSocketConnected = () => {
+  const [isConnected, setIsConnected] = useState(socket.connected);
+
+  useEffect(() => {
+    const onConnect = () => setIsConnected(true);
+    const onDisconnect = () => setIsConnected(false);
+
+    socket.on("connect", onConnect);
+    socket.on("disconnect", onDisconnect);
+
+    return () => {
+      socket.off("connect", onConnect);
+      socket.off("disconnect", onDisconnect);
+    };
+  }, []);
+
+  return isConnected;
+};

--- a/packages/client/src/hooks/useSocketEmit.ts
+++ b/packages/client/src/hooks/useSocketEmit.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react";
+import { socket } from "@/services/socket";
+
+export const useSocketEmit = () => {
+  const pendingRef = useRef<Map<string, unknown>>(new Map());
+
+  useEffect(() => {
+    const flushPending = () => {
+      pendingRef.current.forEach((data, event) => {
+        socket.emit(event, data);
+      });
+      pendingRef.current.clear();
+    };
+
+    socket.on("connect", flushPending);
+
+    return () => {
+      socket.off("connect", flushPending);
+      pendingRef.current.clear();
+    };
+  }, []);
+
+  return (event: string, data: unknown) => {
+    if (socket.connected) {
+      socket.emit(event, data);
+    } else {
+      pendingRef.current.set(event, data);
+    }
+  };
+};

--- a/packages/client/src/hooks/useSocketEmit.ts
+++ b/packages/client/src/hooks/useSocketEmit.ts
@@ -1,30 +1,9 @@
-import { useEffect, useRef } from "react";
 import { socket } from "@/services/socket";
 
 export const useSocketEmit = () => {
-  const pendingRef = useRef<Map<string, unknown>>(new Map());
-
-  useEffect(() => {
-    const flushPending = () => {
-      pendingRef.current.forEach((data, event) => {
-        socket.emit(event, data);
-      });
-      pendingRef.current.clear();
-    };
-
-    socket.on("connect", flushPending);
-
-    return () => {
-      socket.off("connect", flushPending);
-      pendingRef.current.clear();
-    };
-  }, []);
-
   return (event: string, data: unknown) => {
     if (socket.connected) {
       socket.emit(event, data);
-    } else {
-      pendingRef.current.set(event, data);
     }
   };
 };


### PR DESCRIPTION
## 📋 Summary

- `emitWithConnection` was duplicated verbatim in `request-controls.tsx` and `request-editor.tsx`
- Extracted the logic into a `useSocketEmit` hook under `packages/client/src/hooks/`
- Both components now consume the hook instead of defining their own implementation

## 🛠 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] ⚙️ Config / Chore
- [ ] 📄 Docs

## 🔍 How was it tested?

1. `pnpm dev` — verify client starts without errors
2. Join a room, edit URL/method/headers/body and confirm changes sync in another tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized socket emission handling across request components for cleaner code.
* **Bug Fixes**
  * Improved reliability: edits to requests (method, URL, body, headers, params) are queued when disconnected and automatically sent after reconnect, reducing lost updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->