### PR TITLE
fix: sync isLoading and response from IRoomState on join

### DIFF
--- a/packages/client/src/hooks/useRoomConnection.ts
+++ b/packages/client/src/hooks/useRoomConnection.ts
@@ -15,7 +15,10 @@ export const useRoomConnection = (roomId: string) => {
 
     const onSyncState = (roomState: IRoomState) => {
       console.log("Received state from server:", roomState);
-      useAppStore.getState().setRequest(roomState.request);
+      const store = useAppStore.getState();
+      store.setRequest(roomState.request);
+      store.setLoading(roomState.isLoading);
+      store.setResponse(roomState.response);
     };
 
     const onBroadcastChange = (updatedData: { field: string, value: any }) => {


### PR DESCRIPTION
## 📋 Summary
- `onSyncState` was only syncing `request` from `IRoomState`, silently dropping `isLoading` and `response` on join.
- Users joining mid-flight didn't see the loading spinner; users joining after a completed request saw an empty response panel.
- Fix: also call `setLoading(roomState.isLoading)` and `setResponse(roomState.response)` in `onSyncState`.

## 🛠 Type of Change
- [x] 🐛 Bug fix

## 🔍 How was it tested?
1. Open two browser tabs on the same room.
2. In tab A, send a slow request (or throttle the network) — tab B should show the loading spinner immediately after joining.
3. Complete the request in tab A, then open a new tab on the same room — the response should be visible without re-sending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced state synchronization to properly sync loading and response states from the server alongside existing request data, improving overall state consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->